### PR TITLE
Optimize ORSet additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 _build/
 test/.rebar3/
 TEST-file_"antidote_crdt.app".xml
+*.swp
+src/*.swp
+test/*.swp

--- a/src/antidote_crdt_orset.erl
+++ b/src/antidote_crdt_orset.erl
@@ -173,9 +173,7 @@ create_downstreams(CreateDownstream, [Elem1|ElemsRest]=Elems, [{Elem2, Tokens}|O
         true ->
             DownstreamOp = CreateDownstream(Elem1, Tokens),
             create_downstreams(CreateDownstream, ElemsRest, ORSet, [DownstreamOp|DownstreamOps])
-    end;
-create_downstreams(CreateDownstream, Elems, [_|ORSet], DownstreamOps) ->
-    create_downstreams(CreateDownstream, Elems, ORSet, DownstreamOps).
+    end.
 
 %% @private apply a list of downstream ops to a given orset
 apply_downstreams([], ORSet) ->

--- a/src/antidote_crdt_orset.erl
+++ b/src/antidote_crdt_orset.erl
@@ -76,6 +76,11 @@
     | {remove_all, [member()]}
     | {reset, {}}.
 
+%% The downstream op is a list of triples.
+%% In each triple:
+%%  - the first component is the elem that was added or removed
+%%  - the second component is the list of supporting tokens to be added
+%%  - the third component is the list of supporting tokens to be removed
 -type downstream_op() :: [{member(), tokens(), tokens()}].
 
 -type member() :: term().
@@ -131,11 +136,6 @@ downstream({reset, {}}, ORSet) ->
     downstream({remove_all, value(ORSet)}, ORSet).
 
 %% @doc apply downstream operations and update an `orset()'.
-%% The downstream op is a list of triples.
-%% In each triple:
-%%  - the first component is the elem that was added or removed
-%%  - the second component is the list of supporting tokens to be added
-%%  - the third component is the list of supporting tokens to be removed
 -spec update(downstream_op(), orset()) -> {ok, orset()}.
 update(DownstreamOps, ORSet0) ->
     ORSet = lists:foldl(

--- a/src/antidote_crdt_orset.erl
+++ b/src/antidote_crdt_orset.erl
@@ -49,7 +49,6 @@
 %% Callbacks
 -export([ new/0,
           value/1,
-          value/2,
           downstream/2,
           update/2,
           equal/2,
@@ -59,11 +58,6 @@
           require_state_downstream/1
         ]).
 
-%% Others
--export([ precondition_context/1,
-          stats/1
-        ]).
-
 -behaviour(antidote_crdt).
 
 -ifdef(TEST).
@@ -71,7 +65,7 @@
 -endif.
 
 -export_type([orset/0, binary_orset/0, orset_op/0]).
--opaque orset() :: orddict:orddict().
+-opaque orset() :: orddict:orddict(member(), tokens()).
 
 -type binary_orset() :: binary(). %% A binary that from_binary/1 will operate on.
 
@@ -82,115 +76,88 @@
     | {remove_all, [member()]}
     | {reset, {}}.
 
+-type downstream_op() :: [{member(), tokens(), tokens()}].
+
 -type member() :: term().
+-type token() :: binary().
+-type tokens() :: [token()].
 
 -spec new() -> orset().
 new() ->
     orddict:new().
 
-%% @doc
-%% without parameter: return all existing elements in the `orset()'
-%% {fragment, elem}: create and return a new `orset()' with all metadata
-%% of an element
-%% {tokens, elem}: returns all uniques tokens of an element in the set
+%% @doc return all existing elements in the `orset()'.
 -spec value(orset()) -> [member()].
-value(ORDict) ->
-    orddict:fetch_keys(ORDict).
-
--spec value({fragment, member()}, orset()) -> orset();
-           ({tokens, member()}, orset()) -> [binary()].
-value({fragment, Elem}, ORSet) ->
-    case value({tokens, Elem}, ORSet) of
-        [] ->
-            orddict:new();
-        Tokens ->
-            orddict:store(Elem, Tokens, orddict:new())
-    end;
-value({tokens, Elem}, ORSet) ->
-    case orddict:find(Elem, ORSet) of
-        error ->
-            [];
-        {ok, Tokens} ->
-            Tokens
-    end;
-value(_, ORSet) ->
-    value(ORSet).
+value(ORSet) ->
+    orddict:fetch_keys(ORSet).
 
 %% @doc generate downstream operations.
-%% If the operation is add or add_all, generate unique tokens for each element
-%% If the operation is remove or remove_all, fetches all unique tokens for
-%% these elements existing in the `orset()'.
--spec downstream(orset_op(), orset()) -> {ok, orset_op()}.
-downstream({add, Elem}, _ORDict) ->
+%% If the operation is add or add_all, generate unique tokens for
+%% each element and fetches the current supporting tokens.
+%% If the operation is remove or remove_all, fetches current
+%% supporting tokens of these elements existing in the `orset()'.
+-spec downstream(orset_op(), orset()) -> {ok, downstream_op()}.
+downstream({add, Elem}, ORSet) ->
     Token = unique(),
-    {ok, {add, {Elem, [Token]}}};
-downstream({add_all, Elems}, _ORDict0) ->
-    DownstreamOp = lists:foldl(fun(Elem, Sum) ->
-                                       Token = unique(),
-                                       Sum ++ [{Elem, [Token]}]
-                               end, [], Elems),
-    {ok, {add_all, DownstreamOp}};
-downstream({remove, Elem}, ORDict) ->
-    ToRemove = value({tokens, Elem}, ORDict),
-    {ok, {remove, {Elem, ToRemove}}};
-downstream({remove_all, Elems}, ORDict) ->
-    ToRemove = lists:foldl(fun(Elem, Sum) ->
-                                   Sum ++ [{Elem, value({tokens, Elem}, ORDict)}]
-                           end, [], Elems),
-    {ok, {remove_all, ToRemove}};
-downstream({reset, {}}, ORDict) ->
+    ToRemove = get_supporting_tokens(Elem, ORSet),
+    DownstreamOp = {Elem, [Token], ToRemove},
+    {ok, [DownstreamOp]};
+downstream({add_all, Elems}, ORSet) ->
+    DownstreamOps = sets:fold(
+        fun(Elem, Ops) ->
+            {ok, [Op]} = downstream({add, Elem}, ORSet),
+            [Op | Ops]
+        end,
+        [],
+        sets:from_list(Elems)
+    ),
+    {ok, DownstreamOps};
+downstream({remove, Elem}, ORSet) ->
+    ToRemove = get_supporting_tokens(Elem, ORSet),
+    DownstreamOp = {Elem, [], ToRemove},
+    {ok, [DownstreamOp]};
+downstream({remove_all, Elems}, ORSet) ->
+    DownstreamOps = sets:fold(
+        fun(Elem, Ops) ->
+            {ok, [Op]} = downstream({remove, Elem}, ORSet),
+            [Op | Ops]
+        end,
+        [],
+        sets:from_list(Elems)
+    ),
+    {ok, DownstreamOps};
+downstream({reset, {}}, ORSet) ->
     % reset is like removing all elements
-    downstream({remove_all, value(ORDict)}, ORDict).
+    downstream({remove_all, value(ORSet)}, ORSet).
 
 %% @doc apply downstream operations and update an `orset()'.
-%% The first parameter denotes this operation is for adding or removing elements.
-%% For add or add_all, the second element of the tuple is a list of elements and tokens to add
-%% For remove or remove_all, the second element of the tuple is a list of elements and their tokens
-%% to remove.
-%% For update, the second element of the tuple is a list of updates to apply, each of which can
-%% either be add, add_all or remove, remove_all.
--spec update(orset_op(), orset()) ->
-                    {ok, orset()}.
-update({add, {Elem, [Token|_]}}, ORDict) ->
-    add_elem(Elem, Token, ORDict);
-update({add_all, Elems}, ORDict0) ->
-    OD = lists:foldl(fun(Elem, ORDict) ->
-                             {ok, ORDict1} = update({add, Elem}, ORDict),
-                             ORDict1
-                     end, ORDict0, Elems),
-    {ok, OD};
-update({remove, Elem}, ORDict) ->
-    remove_elem(Elem, ORDict);
-update({remove_all, Elems}, ORDict0) ->
-    remove_elems(Elems, ORDict0).
+%% The downstream op is a list of triples.
+%% In each triple:
+%%  - the first component is the elem that was added or removed
+%%  - the second component is the list of supporting tokens to be added
+%%  - the third component is the list of supporting tokens to be removed
+-spec update(downstream_op(), orset()) -> {ok, orset()}.
+update(DownstreamOps, ORSet0) ->
+    ORSet = lists:foldl(
+        fun({Elem, ToAdd, ToRemove}, ORSet1) ->
+            CurrentTokens = get_supporting_tokens(Elem, ORSet1),
+            Tokens = (CurrentTokens ++ ToAdd) -- ToRemove,
+            case Tokens of
+                [] ->
+                    orddict:erase(Elem, ORSet1);
+                _ ->
+                    orddict:store(Elem, Tokens, ORSet1)
+            end
+        end,
+        ORSet0,
+        DownstreamOps
+    ),
+    {ok, ORSet}.
 
 -spec equal(orset(), orset()) -> boolean().
-equal(ORDictA, ORDictB) ->
-    ORDictA == ORDictB. % Everything inside is ordered, so this should work
-
-%% @doc the precondition context is a fragment of the CRDT that
-%% operations with pre-conditions can be applied too.  In the case of
-%% OR-Sets this is the set of adds observed.  The system can then
-%% apply a remove to this context and merge it with a replica.
-%% Especially useful for hybrid op/state systems where the context of
-%% an operation is needed at a replica without sending the entire
-%% state to the client.
--spec precondition_context(orset()) -> orset().
-precondition_context(ORDict) ->
-    orddict:fold(fun(Elem, Tokens, ORDict1) ->
-            case minimum_tokens(Tokens) of
-                []      -> ORDict1;
-                Tokens1 -> orddict:store(Elem, Tokens1, ORDict1)
-            end
-        end, orddict:new(), ORDict).
-
--spec stats(orset()) -> [{atom(), number()}].
-stats(ORSet) ->
-    [ {S, stat(S, ORSet)} || S <- [element_count] ].
-
--spec stat(atom(), orset()) -> integer().
-stat(element_count, ORSet) ->
-    orddict:size(ORSet).
+equal(ORSetA, ORSetB) ->
+    % Everything inside is ordered, so this should work
+    ORSetA == ORSetB.
 
 -include_lib("riak_dt/include/riak_dt_tags.hrl").
 -define(TAG, ?DT_ORSET_TAG).
@@ -205,63 +172,33 @@ from_binary(<<?TAG:8/integer, ?V1_VERS:8/integer, Bin/binary>>) ->
     %% @TODO something smarter
     {ok, binary_to_term(Bin)}.
 
-%% Private
-%% @doc add an element and its token to the `orset()'.
-add_elem(Elem, Token, ORDict) ->
-    case orddict:find(Elem, ORDict) of
-        {ok, Tokens} ->
-            case lists:member(Token, Tokens) of
-                true ->
-                    {ok, ORDict};
-                false ->
-                    {ok, orddict:store(Elem, Tokens ++ [Token], ORDict)}
-            end;
-        error ->
-            {ok, orddict:store(Elem, [Token], ORDict)}
-    end.
-
-%% @doc remove all tokens of the element from the `orset()'.
-remove_elem({Elem, RemoveTokens}, ORDict) ->
-    case orddict:find(Elem, ORDict) of
-        {ok, Tokens} ->
-            RestTokens = Tokens -- RemoveTokens,
-            case RestTokens of
-                [] ->
-                    {ok, orddict:erase(Elem, ORDict)};
-                _ ->
-                    {ok, orddict:store(Elem, RestTokens, ORDict)}
-            end;
-        error ->
-            {ok, ORDict}
-    end.
-
-remove_elems([], ORDict) ->
-    {ok, ORDict};
-remove_elems([Elem|Rest], ORDict) ->
-    {ok, ORDict1} = remove_elem(Elem, ORDict),
-    remove_elems(Rest, ORDict1).
-
 %% @doc generate a unique identifier (best-effort).
+-spec unique() -> token().
 unique() ->
     crypto:strong_rand_bytes(20).
 
-minimum_tokens(Tokens) ->
-    orddict:filter(fun(_Token, Removed) ->
-            not Removed
-        end, Tokens).
+%% @doc returns the list of tokens in the `orset()'
+%%      that support a given `member()'.
+-spec get_supporting_tokens(member(), orset()) -> tokens().
+get_supporting_tokens(Elem, ORSet) ->
+    case orddict:find(Elem, ORSet) of
+        error ->
+            [];
+        {ok, Tokens} ->
+            Tokens
+    end.
 
 %% @doc The following operation verifies
 %%      that Operation is supported by this particular CRDT.
 is_operation({add, _Elem}) -> true;
 is_operation({add_all, L}) when is_list(L) -> true;
-is_operation({remove, _Elem}) ->
-    true;
+is_operation({remove, _Elem}) -> true;
 is_operation({remove_all, L}) when is_list(L) -> true;
 is_operation({reset, {}}) -> true;
 is_operation(_) -> false.
 
-require_state_downstream({add, _}) -> false;
-require_state_downstream({add_all, _}) -> false;
+require_state_downstream({add, _}) -> true;
+require_state_downstream({add_all, _}) -> true;
 require_state_downstream({remove, _}) -> true;
 require_state_downstream({remove_all, _}) -> true;
 require_state_downstream({reset, {}}) -> true.
@@ -270,21 +207,22 @@ require_state_downstream({reset, {}}) -> true.
 %% EUnit tests
 %% ===================================================================
 -ifdef(TEST).
+
 new_test() ->
     ?assertEqual(orddict:new(), new()).
 
 add_test() ->
+    Elem = <<"foo">>,
+    Elems = [<<"li">>, <<"manu">>],
     Set1 = new(),
-    {ok, DownstreamOp1} = downstream({add, <<"foo">>}, Set1),
-    ?assertMatch({add, {<<"foo">>, _}}, DownstreamOp1),
-    {ok, DownstreamOp2} = downstream({add_all, [<<"li">>, <<"manu">>]}, Set1),
-    ?assertMatch({add_all, [{<<"li">>, _}, {<<"manu">>, _}]}, DownstreamOp2),
+    {ok, DownstreamOp1} = downstream({add, Elem}, Set1),
+    ?assertMatch([{Elem, _, _}], DownstreamOp1),
+    {ok, DownstreamOp2} = downstream({add_all, Elems}, Set1),
+    ?assertMatch([{<<"li">>, _, _}, {<<"manu">>, _, _}], DownstreamOp2),
     {ok, Set2} = update(DownstreamOp1, Set1),
-    {_, Elem1} = DownstreamOp1,
-    ?assertEqual([Elem1], orddict:to_list(Set2)),
+    ?assertEqual([Elem], value(Set2)),
     {ok, Set3} = update(DownstreamOp2, Set1),
-    {_, Elems2} = DownstreamOp2,
-    ?assertEqual(Elems2, orddict:to_list(Set3)).
+    ?assertEqual(Elems, value(Set3)).
 
 value_test() ->
     Set1 = new(),
@@ -294,14 +232,7 @@ value_test() ->
     ?assertEqual([<<"foo">>], value(Set2)),
     {ok, DownstreamOp2} = downstream({add_all, [<<"foo">>, <<"li">>, <<"manu">>]}, Set2),
     {ok, Set3} = update(DownstreamOp2, Set2),
-    ?assertEqual([<<"foo">>, <<"li">>, <<"manu">>], value(Set3)),
-
-    {_, {_, Token1}} = DownstreamOp1,
-    {_, [{_, Token2}|_]} = DownstreamOp2,
-    ?assertEqual(Token1, value({tokens, <<"foo">>}, Set2)),
-    ?assertEqual(Token1 ++ Token2, value({tokens, <<"foo">>}, Set3)),
-
-    ?assertEqual(orddict:store(<<"foo">>, Token1 ++ Token2, orddict:new()), value({fragment, <<"foo">>}, Set3)).
+    ?assertEqual([<<"foo">>, <<"li">>, <<"manu">>], value(Set3)).
 
 remove_test() ->
     Set1 = new(),


### PR DESCRIPTION
- optimizes additions by removing the supporting tokens that are already there (however this requires `require_state_downstream` set to `true` for these operations)
- simplifies by producing only one type of downstream op `{Elem, TokensToAdd, TokensToRemove}`
- removes what appeared to be some legacy code from Riak (I don't know if this is okay)

cc @gyounes @CBaquero 