### PR TITLE
Small performance optimization in aw-set

### DIFF
--- a/src/antidote_crdt_set_aw.erl
+++ b/src/antidote_crdt_set_aw.erl
@@ -177,7 +177,7 @@ create_downstreams(CreateDownstream, [Elem1|ElemsRest]=Elems, [{Elem2, Tokens}|S
         Elem1 > Elem2 ->
             create_downstreams(CreateDownstream, Elems, Set_awRest, DownstreamOps);
         true ->
-            DownstreamOp = CreateDownstream(Elem1, Tokens),
+            DownstreamOp = CreateDownstream(Elem1, []),
             create_downstreams(CreateDownstream, ElemsRest, Set_aw, [DownstreamOp|DownstreamOps])
     end.
 


### PR DESCRIPTION
The old code added the tokens from the next element to the set of
removed tokens. Since tokens are unique, this had no effect on
correctness but it made the messages bigger than necessary.