### PR TITLE
Removes unused type exports

### DIFF
--- a/src/antidote_crdt_counter_b.erl
+++ b/src/antidote_crdt_counter_b.erl
@@ -25,14 +25,6 @@
 %% List of the contributors to the development of Antidote: see AUTHORS file.
 %% Description and complete License: see LICENSE file.
 
-%% -------------------------------------------------------------------
-%% -*- coding: utf-8 -*-
-%% --------------------------------------------------------------------------
-%%
-%% antidote_crdt_counter_b: A convergent, replicated, operation-based bounded counter.
-%%
-%% --------------------------------------------------------------------------
-
 %% @doc
 %% An operation based implementation of the bounded counter CRDT.
 %% This counter is able to maintain a non-negative value by

--- a/src/antidote_crdt_counter_b.erl
+++ b/src/antidote_crdt_counter_b.erl
@@ -60,10 +60,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
--export_type([antidote_crdt_counter_b/0, binary_antidote_crdt_counter_b/0, antidote_crdt_counter_b_op/0, id/0]).
-
 -type antidote_crdt_counter_b() :: {orddict:orddict(), orddict:orddict()}.
--type binary_antidote_crdt_counter_b() :: binary().
 -type antidote_crdt_counter_b_op() :: antidote_crdt_counter_b_anon_op() | antidote_crdt_counter_b_src_op().
 -type antidote_crdt_counter_b_anon_op() :: {transfer, {pos_integer(), id(), id()}} |
     {increment, {pos_integer(), id()}} | {decrement, {pos_integer(), id()}}.

--- a/src/antidote_crdt_flag_dw.erl
+++ b/src/antidote_crdt_flag_dw.erl
@@ -54,8 +54,7 @@
 -define(TAG, 77).
 -define(V1_VERS, 1).
 
--export_type([flag_dw/0]).
--opaque flag_dw() :: {antidote_crdt_flag_helper:tokens(), antidote_crdt_flag_helper:tokens()}.
+-type flag_dw() :: {antidote_crdt_flag_helper:tokens(), antidote_crdt_flag_helper:tokens()}.
 
 %% SeenTokens, NewEnableTokens, NewDisableTokens
 -type downstream_op() :: {antidote_crdt_flag_helper:tokens(), antidote_crdt_flag_helper:tokens(), antidote_crdt_flag_helper:tokens()}.

--- a/src/antidote_crdt_flag_ew.erl
+++ b/src/antidote_crdt_flag_ew.erl
@@ -54,7 +54,7 @@
 -define(TAG, 77).
 -define(V1_VERS, 1).
 
--type flag_ew() :: antidote_crdt_flag_helper:flag().
+-type flag_ew() :: antidote_crdt_flag_helper:tokens().
 
 %% SeenTokens, NewTokens
 -type downstream_op() :: {antidote_crdt_flag_helper:tokens(), antidote_crdt_flag_helper:tokens()}.

--- a/src/antidote_crdt_flag_ew.erl
+++ b/src/antidote_crdt_flag_ew.erl
@@ -54,8 +54,7 @@
 -define(TAG, 77).
 -define(V1_VERS, 1).
 
--export_type([flag_ew/0]).
--opaque flag_ew() :: antidote_crdt_flag_helper:flag().
+-type flag_ew() :: antidote_crdt_flag_helper:flag().
 
 %% SeenTokens, NewTokens
 -type downstream_op() :: {antidote_crdt_flag_helper:tokens(), antidote_crdt_flag_helper:tokens()}.

--- a/src/antidote_crdt_flag_helper.erl
+++ b/src/antidote_crdt_flag_helper.erl
@@ -44,8 +44,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
--export_type([flag/0, binary_flag/0, op/0]).
--opaque flag() :: tokens().
+-export_type([tokens/0, binary_flag/0, op/0]).
 
 -type binary_flag() :: binary(). %% A binary that from_binary/1 will operate on.
 

--- a/src/antidote_crdt_register_lww.erl
+++ b/src/antidote_crdt_register_lww.erl
@@ -51,9 +51,7 @@
           require_state_downstream/1
         ]).
 
--export_type([antidote_crdt_register_lww/0, antidote_crdt_register_lww_op/0]).
-
--opaque antidote_crdt_register_lww() :: {non_neg_integer(), term()}.
+-type antidote_crdt_register_lww() :: {non_neg_integer(), term()}.
 
 -type antidote_crdt_register_lww_op() :: {assign, term(), non_neg_integer()}  | {assign, term()}.
 

--- a/src/antidote_crdt_register_mv.erl
+++ b/src/antidote_crdt_register_mv.erl
@@ -59,9 +59,6 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
--export_type([antidote_crdt_register_mv/0, antidote_crdt_register_mv_op/0]).
-
-%% TODO: make opaque
 -type antidote_crdt_register_mv() :: [{term(), uniqueToken()}].
 -type uniqueToken() :: term().
 -type antidote_crdt_register_mv_effect() ::

--- a/src/antidote_crdt_set_aw.erl
+++ b/src/antidote_crdt_set_aw.erl
@@ -71,8 +71,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
--export_type([antidote_crdt_set_aw/0, binary_antidote_crdt_set_aw/0, antidote_crdt_set_aw_op/0]).
--opaque antidote_crdt_set_aw() :: orddict:orddict(member(), tokens()).
+-type antidote_crdt_set_aw() :: orddict:orddict(member(), tokens()).
 
 -type binary_antidote_crdt_set_aw() :: binary(). %% A binary that from_binary/1 will operate on.
 

--- a/src/antidote_crdt_set_rw.erl
+++ b/src/antidote_crdt_set_rw.erl
@@ -71,8 +71,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
--export_type([antidote_crdt_set_rw/0, binary_antidote_crdt_set_rw/0, antidote_crdt_set_rw_op/0]).
--opaque antidote_crdt_set_rw() :: orddict:orddict(term(), {tokens(), tokens()}).
+-type antidote_crdt_set_rw() :: orddict:orddict(term(), {tokens(), tokens()}).
 
 -type binary_antidote_crdt_set_rw() :: binary(). %% A binary that from_binary/1 will operate on.
 


### PR DESCRIPTION
As far as I can see the exported types are neither used in `antidote_crdt` nor in `antidote` itself, and as only a few of the CRDT implementations export themselves I think its better to be consistent and remove them all.

After removing the exports it showed that the type `binary_antidote_crdt_counter_b()` in the bounded counter is actually unsued, thus this PR removes it as well.

This PR also changes the "not anymore exported types" from `opaque` to `type`, removes a `TODO` concerning `opaque`-types and removes a documentation header in the bounded counter _(only place where it shows up)_ to start making the docs more consistent.