### PR TITLE
Make identation consistent

### DIFF
--- a/src/antidote_crdt.erl
+++ b/src/antidote_crdt.erl
@@ -106,14 +106,14 @@ is_type(_)                          -> false.
 % Returns the initial CRDT state for the given Type
 -spec new(typ()) -> crdt().
 new(Type) ->
-  true = is_type(Type),
-  Type:new().
+    true = is_type(Type),
+    Type:new().
 
 % Reads the value from a CRDT state
 -spec value(typ(), crdt()) -> any().
 value(Type, State) ->
-  true = is_type(Type),
-  Type:value(State).
+    true = is_type(Type),
+    Type:value(State).
 
 % Computes the downstream effect for a given update operation and current state.
 % This has to be called once at the source replica.
@@ -122,9 +122,9 @@ value(Type, State) ->
 % and the atom 'ignore' can be passed instead (see function require_state_downstream).
 -spec downstream(typ(), update(), crdt() | ignore) -> {ok, effect()} | {error, reason()}.
 downstream(Type, Update, State) ->
-  true = is_type(Type),
-  true = Type:is_operation(Update),
-  Type:downstream(Update, State).
+    true = is_type(Type),
+    true = Type:is_operation(Update),
+    Type:downstream(Update, State).
 
 % Updates the state of a CRDT by applying a downstream effect calculated
 % using the downstream function.
@@ -133,21 +133,21 @@ downstream(Type, Update, State) ->
 % then Eff1 has to be applied before Eff2 on all replicas.
 -spec update(typ(), effect(), crdt()) -> {ok, crdt()}.
 update(Type, Effect, State) ->
-  true = is_type(Type),
-  Type:update(Effect, State).
+    true = is_type(Type),
+    Type:update(Effect, State).
 
 % Checks whether the current state is required by the downstream function
 % for a specific type and update operation
 -spec require_state_downstream(typ(), update()) -> boolean().
 require_state_downstream(Type, Update) ->
-  true = is_type(Type),
-  Type:require_state_downstream(Update).
+    true = is_type(Type),
+    Type:require_state_downstream(Update).
 
 % Checks whether the given update operation is valid for the given type
 -spec is_operation(typ(), update()) -> boolean().
 is_operation(Type, Update) ->
-  true = is_type(Type),
-  Type:is_operation(Update).
+    true = is_type(Type),
+    Type:is_operation(Update).
 
 -spec to_binary(crdt()) -> binary().
 to_binary(Term) ->

--- a/src/antidote_crdt_counter_fat.erl
+++ b/src/antidote_crdt_counter_fat.erl
@@ -100,22 +100,22 @@ update({Token, Value}, FatCtr) ->
     % insert new value
     {ok, orddict:store(Token, Value, FatCtr)};
 update(Overridden, FatCtr) ->
-  {ok, apply_downstreams(Overridden, FatCtr)}.
+    {ok, apply_downstreams(Overridden, FatCtr)}.
 
 %% @private apply a list of downstream ops to a given orset
 apply_downstreams([], FatCtr) ->
-  FatCtr;
+    FatCtr;
 apply_downstreams(_Tokens, []) ->
-  [];
+    [];
 apply_downstreams([Token1|TokensRest]=Tokens, [{Token2, Value2}|FatCtrRest]=FatCtr) ->
-  if
-    Token1 == Token2 ->
-      apply_downstreams(TokensRest, FatCtrRest);
-    Token1 > Token2 ->
-      [{Token2, Value2} | apply_downstreams(Tokens, FatCtrRest)];
-    true ->
-      apply_downstreams(TokensRest, FatCtr)
-  end.
+    if
+        Token1 == Token2 ->
+            apply_downstreams(TokensRest, FatCtrRest);
+        Token1 > Token2 ->
+            [{Token2, Value2} | apply_downstreams(Tokens, FatCtrRest)];
+        true ->
+            apply_downstreams(TokensRest, FatCtr)
+    end.
 
 -spec equal(state(), state()) -> boolean().
 equal(FatCtr1, FatCtr2) ->
@@ -134,7 +134,7 @@ from_binary(<<?TAG:8/integer, ?V1_VERS:8/integer, Bin/binary>>) ->
     {ok, antidote_crdt:from_binary(Bin)}.
 
 is_bottom(FatCtr) ->
-  FatCtr == new().
+    FatCtr == new().
 
 %% @doc The following operation verifies
 %%      that Operation is supported by this particular CRDT.
@@ -145,7 +145,7 @@ is_operation({reset, {}}) -> true;
 is_operation(_) -> false.
 
 require_state_downstream(Op) ->
-  Op == {reset, {}}.
+    Op == {reset, {}}.
 
 
 

--- a/src/antidote_crdt_flag_dw.erl
+++ b/src/antidote_crdt_flag_dw.erl
@@ -61,32 +61,32 @@
 
 -spec new() -> flag_dw().
 new() ->
-  {[], []}.
+    {[], []}.
 
 -spec value(flag_dw()) -> boolean().
 value({EnableTokens, DisableTokens}) ->
-  DisableTokens == [] andalso EnableTokens =/= [].
+    DisableTokens == [] andalso EnableTokens =/= [].
 
 -spec downstream(antidote_crdt_flag_helper:op(), flag_dw()) -> {ok, downstream_op()}.
 downstream({disable, {}}, {EnableTokens, DisableTokens}) ->
-  {ok, {EnableTokens ++ DisableTokens, [], [antidote_crdt_flag_helper:unique()]}};
+    {ok, {EnableTokens ++ DisableTokens, [], [antidote_crdt_flag_helper:unique()]}};
 downstream({enable, {}}, {EnableTokens, DisableTokens}) ->
-  {ok, {EnableTokens ++ DisableTokens, [antidote_crdt_flag_helper:unique()], []}};
+    {ok, {EnableTokens ++ DisableTokens, [antidote_crdt_flag_helper:unique()], []}};
 downstream({reset, {}}, {EnableTokens, DisableTokens}) ->
-  {ok, {EnableTokens ++ DisableTokens, [], []}}.
+    {ok, {EnableTokens ++ DisableTokens, [], []}}.
 
 -spec update(downstream_op(), flag_dw()) -> {ok, flag_dw()}.
-  update({SeenTokens, NewEnableTokens, NewDisableTokens}, {CurrentEnableTokens, CurrentDisableTokens}) ->
+update({SeenTokens, NewEnableTokens, NewDisableTokens}, {CurrentEnableTokens, CurrentDisableTokens}) ->
     FinalEnableTokens = (CurrentEnableTokens ++ NewEnableTokens) -- SeenTokens,
     FinalDisableTokens = (CurrentDisableTokens ++ NewDisableTokens) -- SeenTokens,
     {ok, {FinalEnableTokens, FinalDisableTokens}}.
 
 -spec equal(flag_dw(), flag_dw()) -> boolean().
-  equal(Flag1, Flag2) ->
+equal(Flag1, Flag2) ->
     Flag1 == Flag2.
 
 -spec to_binary(flag_dw()) -> antidote_crdt_flag_helper:binary_flag().
-  to_binary(Flag) ->
+to_binary(Flag) ->
     %% @TODO something smarter
     <<?TAG:8/integer, ?V1_VERS:8/integer, (term_to_binary(Flag))/binary>>.
 
@@ -97,7 +97,7 @@ from_binary(<<?TAG:8/integer, ?V1_VERS:8/integer, Bin/binary>>) ->
 is_operation(A) -> antidote_crdt_flag_helper:is_operation(A).
 
 is_bottom(Flag) ->
-  Flag == new().
+    Flag == new().
 
 require_state_downstream(A) -> antidote_crdt_flag_helper:require_state_downstream(A).
 

--- a/src/antidote_crdt_flag_ew.erl
+++ b/src/antidote_crdt_flag_ew.erl
@@ -61,31 +61,31 @@
 
 -spec new() -> flag_ew().
 new() ->
-  [].
+    [].
 
 -spec value(flag_ew()) -> boolean().
 value(EnableTokens) ->
-  EnableTokens =/= [].
+    EnableTokens =/= [].
 
 -spec downstream(antidote_crdt_flag_helper:op(), flag_ew()) -> {ok, downstream_op()}.
 downstream({disable, {}}, Tokens) ->
-  {ok, {Tokens, []}};
+    {ok, {Tokens, []}};
 downstream({enable, {}}, Tokens) ->
-  {ok, {Tokens, [antidote_crdt_flag_helper:unique()]}};
+    {ok, {Tokens, [antidote_crdt_flag_helper:unique()]}};
 downstream({reset, {}}, Tokens) ->
-  {ok, {Tokens, []}}.
+    {ok, {Tokens, []}}.
 
 -spec update(downstream_op(), flag_ew()) -> {ok, flag_ew()}.
-  update({SeenTokens, NewTokens}, CurrentTokens) ->
+update({SeenTokens, NewTokens}, CurrentTokens) ->
     FinalTokens = (CurrentTokens ++ NewTokens) -- SeenTokens,
     {ok, FinalTokens}.
 
 -spec equal(flag_ew(), flag_ew()) -> boolean().
-  equal(Flag1, Flag2) ->
+equal(Flag1, Flag2) ->
     Flag1 == Flag2. % Everything inside is ordered, so this should work
 
 -spec to_binary(flag_ew()) -> antidote_crdt_flag_helper:binary_flag().
-  to_binary(Flag) ->
+to_binary(Flag) ->
     %% @TODO something smarter
     <<?TAG:8/integer, ?V1_VERS:8/integer, (term_to_binary(Flag))/binary>>.
 
@@ -96,7 +96,7 @@ from_binary(<<?TAG:8/integer, ?V1_VERS:8/integer, Bin/binary>>) ->
 is_operation(A) -> antidote_crdt_flag_helper:is_operation(A).
 
 is_bottom(Flag) ->
-  Flag == new().
+    Flag == new().
 
 require_state_downstream(A) -> antidote_crdt_flag_helper:require_state_downstream(A).
 
@@ -105,23 +105,23 @@ require_state_downstream(A) -> antidote_crdt_flag_helper:require_state_downstrea
 %% ===================================================================
 -ifdef(TEST).
 
-  prop1_test() ->
-  Flag0 = new(),
-  % DC1 add a
-  {ok, Enable1Effect} = downstream({enable, {}}, Flag0),
-  {ok, Flag1a} = update(Enable1Effect, Flag0),
-  % DC1 reset
-  {ok, Reset1Effect} = downstream({reset, {}}, Flag1a),
-  {ok, Flag1b} = update(Reset1Effect, Flag1a),
+prop1_test() ->
+    Flag0 = new(),
+    % DC1 add a
+    {ok, Enable1Effect} = downstream({enable, {}}, Flag0),
+    {ok, Flag1a} = update(Enable1Effect, Flag0),
+    % DC1 reset
+    {ok, Reset1Effect} = downstream({reset, {}}, Flag1a),
+    {ok, Flag1b} = update(Reset1Effect, Flag1a),
 
-  io:format("Reset1Effect = ~p~n", [Reset1Effect]),
-  io:format("Enable1Effect = ~p~n", [Enable1Effect]),
+    io:format("Reset1Effect = ~p~n", [Reset1Effect]),
+    io:format("Enable1Effect = ~p~n", [Enable1Effect]),
 
-  io:format("Flag1a = ~p~n", [Flag1a]),
-  io:format("Flag1b = ~p~n", [Flag1b]),
+    io:format("Flag1a = ~p~n", [Flag1a]),
+    io:format("Flag1b = ~p~n", [Flag1b]),
 
-  ?assertEqual(false, value(Flag0)),
-  ?assertEqual(true, value(Flag1a)),
-  ?assertEqual(false, value(Flag1b)).
+    ?assertEqual(false, value(Flag0)),
+    ?assertEqual(true, value(Flag1a)),
+    ?assertEqual(false, value(Flag1b)).
 
 -endif.

--- a/src/antidote_crdt_map_go.erl
+++ b/src/antidote_crdt_map_go.erl
@@ -62,19 +62,19 @@ new() ->
 
 -spec value(antidote_crdt_map_go()) -> [{{Key::term(), Type::atom()}, Value::term()}].
 value(Map) ->
-  lists:sort([{{Key, Type}, Type:value(Value)} || {{Key, Type}, Value} <- dict:to_list(Map)]).
+    lists:sort([{{Key, Type}, Type:value(Value)} || {{Key, Type}, Value} <- dict:to_list(Map)]).
 
 -spec require_state_downstream(antidote_crdt_map_go_op()) -> boolean().
 require_state_downstream(_Op) ->
-  true.
+    true.
 
 
 -spec downstream(antidote_crdt_map_go_op(), antidote_crdt_map_go()) -> {ok, antidote_crdt_map_go_effect()}.
 downstream({update, {{Key, Type}, Op}}, CurrentMap) ->
     % TODO could be optimized for some types
     CurrentValue = case dict:is_key({Key, Type}, CurrentMap) of
-      true -> dict:fetch({Key, Type}, CurrentMap);
-      false -> Type:new()
+        true -> dict:fetch({Key, Type}, CurrentMap);
+        false -> Type:new()
     end,
     {ok, DownstreamOp} = Type:downstream(Op, CurrentValue),
     {ok, {update, {{Key, Type}, DownstreamOp}}};
@@ -84,10 +84,10 @@ downstream({update, Ops}, CurrentMap) when is_list(Ops) ->
 -spec update(antidote_crdt_map_go_effect(), antidote_crdt_map_go()) -> {ok, antidote_crdt_map_go()}.
 update({update, {{Key, Type}, Op}}, Map) ->
     case dict:is_key({Key, Type}, Map) of
-      true -> {ok, dict:update({Key, Type}, fun(V) -> {ok, Value} = Type:update(Op, V), Value end, Map)};
-      false -> NewValue = Type:new(),
-               {ok, NewValueUpdated} = Type:update(Op, NewValue),
-               {ok, dict:store({Key, Type}, NewValueUpdated, Map)}
+        true -> {ok, dict:update({Key, Type}, fun(V) -> {ok, Value} = Type:update(Op, V), Value end, Map)};
+        false -> NewValue = Type:new(),
+                 {ok, NewValueUpdated} = Type:update(Op, NewValue),
+                 {ok, dict:store({Key, Type}, NewValueUpdated, Map)}
     end;
 update({update, Ops}, Map) ->
     apply_ops(Ops, Map).
@@ -95,8 +95,8 @@ update({update, Ops}, Map) ->
 apply_ops([], Map) ->
     {ok, Map};
 apply_ops([Op | Rest], Map) ->
-  {ok, ORDict1} = update(Op, Map),
-  apply_ops(Rest, ORDict1).
+    {ok, ORDict1} = update(Op, Map),
+    apply_ops(Rest, ORDict1).
 
 
 
@@ -113,24 +113,24 @@ to_binary(Policy) ->
 
 from_binary(<<?TAG:8/integer, ?V1_VERS:8/integer, Bin/binary>>) ->
     %% @TODO something smarter
-  {ok, binary_to_term(Bin)}.
+    {ok, binary_to_term(Bin)}.
 
 is_operation(Operation) ->
-  case Operation of
-    {update, {{_Key, Type}, Op}} ->
-      antidote_crdt:is_type(Type)
-        andalso Type:is_operation(Op);
-    {update, Ops} when is_list(Ops) ->
-      distinct([Key || {Key, _} <- Ops])
-      andalso lists:all(fun(Op) -> is_operation({update, Op}) end, Ops);
-    {reset, {}} -> false;
-    _ ->
-      false
-  end.
+    case Operation of
+        {update, {{_Key, Type}, Op}} ->
+            antidote_crdt:is_type(Type)
+                andalso Type:is_operation(Op);
+        {update, Ops} when is_list(Ops) ->
+            distinct([Key || {Key, _} <- Ops])
+                andalso lists:all(fun(Op) -> is_operation({update, Op}) end, Ops);
+        {reset, {}} -> false;
+        _ ->
+            false
+    end.
 
 distinct([]) -> true;
 distinct([X|Xs]) ->
-  not lists:member(X, Xs) andalso distinct(Xs).
+    not lists:member(X, Xs) andalso distinct(Xs).
 
 
 %% ===================================================================
@@ -149,10 +149,10 @@ update_test() ->
     ?assertEqual([{{key1, antidote_crdt_register_lww}, <<"test">>}], value(Map2)).
 
 update2_test() ->
-  Map1 = new(),
-  {ok, Effect1} = downstream({update, [{{a, antidote_crdt_set_aw}, {add, a}}]}, Map1),
-  {ok, Map2} = update(Effect1, Map1),
-  ?assertEqual([{{a, antidote_crdt_set_aw}, [a]}], value(Map2)).
+    Map1 = new(),
+    {ok, Effect1} = downstream({update, [{{a, antidote_crdt_set_aw}, {add, a}}]}, Map1),
+    {ok, Map2} = update(Effect1, Map1),
+    ?assertEqual([{{a, antidote_crdt_set_aw}, [a]}], value(Map2)).
 
 -endif.
 

--- a/src/antidote_crdt_map_rr.erl
+++ b/src/antidote_crdt_map_rr.erl
@@ -87,113 +87,113 @@ new() ->
 
 -spec value(state()) -> value().
 value(Map) ->
-  lists:sort([{{Key, Type}, Type:value(Value)} || {{Key, Type}, Value} <- dict:to_list(Map)]).
+    lists:sort([{{Key, Type}, Type:value(Value)} || {{Key, Type}, Value} <- dict:to_list(Map)]).
 
 % get a value from the map
 % returns empty value if the key is not present in the map
 -spec get(typedKey(), value()) -> term().
 get({_K, Type}=Key, Map) ->
-  case orddict:find(Key, Map) of
-    {ok, Val} -> Val;
-    error -> Type:value(Type:new())
-  end.
+    case orddict:find(Key, Map) of
+        {ok, Val} -> Val;
+        error -> Type:value(Type:new())
+    end.
 
 
 -spec require_state_downstream(op()) -> boolean().
 require_state_downstream(_Op) ->
-  true.
+    true.
 
 -spec downstream(op(), state()) -> {ok, effect()}.
 downstream({update, {{Key, Type}, Op}}, CurrentMap) ->
-  downstream({update, [{{Key, Type}, Op}]}, CurrentMap);
+    downstream({update, [{{Key, Type}, Op}]}, CurrentMap);
 downstream({update, NestedOps}, CurrentMap) ->
-  downstream({batch, {NestedOps, []}}, CurrentMap);
+    downstream({batch, {NestedOps, []}}, CurrentMap);
 downstream({remove, {Key, Type}}, CurrentMap) ->
-  downstream({remove, [{Key, Type}]}, CurrentMap);
+    downstream({remove, [{Key, Type}]}, CurrentMap);
 downstream({remove, Keys}, CurrentMap) ->
-  downstream({batch, {[], Keys}}, CurrentMap);
+    downstream({batch, {[], Keys}}, CurrentMap);
 downstream({batch, {Updates, Removes}}, CurrentMap) ->
-  UpdateEffects = [generate_downstream_update(Op, CurrentMap) || Op <- Updates],
-  RemoveEffects = [generate_downstream_remove(Key, CurrentMap) || Key <- Removes],
-  {ok, {UpdateEffects, RemoveEffects}};
+    UpdateEffects = [generate_downstream_update(Op, CurrentMap) || Op <- Updates],
+    RemoveEffects = [generate_downstream_remove(Key, CurrentMap) || Key <- Removes],
+    {ok, {UpdateEffects, RemoveEffects}};
 downstream({reset, {}}, CurrentMap) ->
-  % reset removes all keys
-  AllKeys = [Key || {Key, _Val} <- value(CurrentMap)],
-  downstream({remove, AllKeys}, CurrentMap).
+    % reset removes all keys
+    AllKeys = [Key || {Key, _Val} <- value(CurrentMap)],
+    downstream({remove, AllKeys}, CurrentMap).
 
 
 -spec generate_downstream_update({typedKey(), Op::term()}, state()) -> nested_downstream().
 generate_downstream_update({{Key, Type}, Op}, CurrentMap) ->
-  CurrentState =
-    case dict:is_key({Key, Type}, CurrentMap) of
-      true -> dict:fetch({Key, Type}, CurrentMap);
-      false -> Type:new()
-    end,
-  {ok, DownstreamEffect} = Type:downstream(Op, CurrentState),
-  {{Key, Type}, {ok, DownstreamEffect}}.
+    CurrentState =
+        case dict:is_key({Key, Type}, CurrentMap) of
+            true -> dict:fetch({Key, Type}, CurrentMap);
+            false -> Type:new()
+        end,
+    {ok, DownstreamEffect} = Type:downstream(Op, CurrentState),
+    {{Key, Type}, {ok, DownstreamEffect}}.
 
 
 -spec generate_downstream_remove(typedKey(), state()) -> nested_downstream().
 generate_downstream_remove({Key, Type}, CurrentMap) ->
-  CurrentState =
-    case dict:is_key({Key, Type}, CurrentMap) of
-      true -> dict:fetch({Key, Type}, CurrentMap);
-      false -> Type:new()
-    end,
-  DownstreamEffect =
-    case Type:is_operation({reset, {}}) of
-      true ->
-        {ok, _} = Type:downstream({reset, {}}, CurrentState);
-      false ->
-        none
-    end,
-  {{Key, Type}, DownstreamEffect}.
+    CurrentState =
+        case dict:is_key({Key, Type}, CurrentMap) of
+            true -> dict:fetch({Key, Type}, CurrentMap);
+            false -> Type:new()
+        end,
+    DownstreamEffect =
+        case Type:is_operation({reset, {}}) of
+            true ->
+                {ok, _} = Type:downstream({reset, {}}, CurrentState);
+            false ->
+                none
+        end,
+    {{Key, Type}, DownstreamEffect}.
 
 
 -spec update(effect(), state()) -> {ok, state()}.
 update({Updates, Removes}, State) ->
-  State2 = lists:foldl(fun(E, S) -> update_entry(E, S)  end, State, Updates),
-  State3 = dict:fold(fun(K, V, S) -> remove_obsolete(K, V, S)  end, new(), State2),
-  State4 = lists:foldl(fun(E, S) -> remove_entry(E, S)  end, State3, Removes),
-  {ok, State4}.
+    State2 = lists:foldl(fun(E, S) -> update_entry(E, S)  end, State, Updates),
+    State3 = dict:fold(fun(K, V, S) -> remove_obsolete(K, V, S)  end, new(), State2),
+    State4 = lists:foldl(fun(E, S) -> remove_entry(E, S)  end, State3, Removes),
+    {ok, State4}.
 
 update_entry({{Key, Type}, {ok, Op}}, Map) ->
-  case dict:find({Key, Type}, Map) of
-    {ok, State} ->
-      {ok, UpdatedState} = Type:update(Op, State),
-      dict:store({Key, Type}, UpdatedState, Map);
-    error ->
-      NewValue = Type:new(),
-      {ok, NewValueUpdated} = Type:update(Op, NewValue),
-      dict:store({Key, Type}, NewValueUpdated, Map)
-  end.
+    case dict:find({Key, Type}, Map) of
+        {ok, State} ->
+            {ok, UpdatedState} = Type:update(Op, State),
+            dict:store({Key, Type}, UpdatedState, Map);
+        error ->
+            NewValue = Type:new(),
+            {ok, NewValueUpdated} = Type:update(Op, NewValue),
+            dict:store({Key, Type}, NewValueUpdated, Map)
+    end.
 
 remove_entry({{Key, Type}, {ok, Op}}, Map) ->
-  case dict:find({Key, Type}, Map) of
-    {ok, State} ->
-      {ok, UpdatedState} = Type:update(Op, State),
-      case is_bottom(Type, UpdatedState) of
-        true ->
-          dict:erase({Key, Type}, Map);
-        false ->
-          dict:store({Key, Type}, UpdatedState, Map)
-      end;
-    error ->
-      Map
-  end;
+    case dict:find({Key, Type}, Map) of
+        {ok, State} ->
+            {ok, UpdatedState} = Type:update(Op, State),
+            case is_bottom(Type, UpdatedState) of
+                true ->
+                    dict:erase({Key, Type}, Map);
+                false ->
+                    dict:store({Key, Type}, UpdatedState, Map)
+            end;
+        error ->
+            Map
+    end;
 remove_entry({{_Key, _Type}, none}, Map) ->
-  Map.
+    Map.
 
 remove_obsolete({Key, Type}, Val, Map) ->
-  case is_bottom(Type, Val) of
-    false ->
-      dict:store({Key, Type}, Val, Map);
-    true ->
-      Map
-  end.
+    case is_bottom(Type, Val) of
+        false ->
+            dict:store({Key, Type}, Val, Map);
+        true ->
+            Map
+    end.
 
 is_bottom(Type, State) ->
-  erlang:function_exported(Type, is_bottom, 1) andalso Type:is_bottom(State).
+    erlang:function_exported(Type, is_bottom, 1) andalso Type:is_bottom(State).
 
 equal(Map1, Map2) ->
     Map1 == Map2. % TODO better implementation (recursive equals)
@@ -206,39 +206,39 @@ to_binary(Policy) ->
     <<?TAG:8/integer, ?V1_VERS:8/integer, (term_to_binary(Policy))/binary>>.
 
 from_binary(<<?TAG:8/integer, ?V1_VERS:8/integer, Bin/binary>>) ->
-  {ok, binary_to_term(Bin)}.
+    {ok, binary_to_term(Bin)}.
 
 is_operation(Operation) ->
-  case Operation of
-    {update, {{_Key, Type}, Op}} ->
-      antidote_crdt:is_type(Type)
-        andalso Type:is_operation(Op);
-    {update, Ops} when is_list(Ops) ->
-      distinct([Key || {Key, _} <- Ops])
-      andalso lists:all(fun(Op) -> is_operation({update, Op}) end, Ops);
-    {remove, {_Key, Type}} ->
-      antidote_crdt:is_type(Type);
-    {remove, Keys} when is_list(Keys) ->
-      distinct(Keys)
-        andalso lists:all(fun(Key) -> is_operation({remove, Key}) end, Keys);
-    {batch, {Updates, Removes}} ->
-      is_list(Updates)
-        andalso is_list(Removes)
-        andalso distinct(Removes ++ [Key || {Key, _} <- Updates])
-        andalso lists:all(fun(Key) -> is_operation({remove, Key}) end, Removes)
-        andalso lists:all(fun(Op) -> is_operation({update, Op}) end, Updates);
-    {reset, {}} -> true;
-    is_bottom -> true;
-    _ ->
-      false
-  end.
+    case Operation of
+        {update, {{_Key, Type}, Op}} ->
+            antidote_crdt:is_type(Type)
+                andalso Type:is_operation(Op);
+        {update, Ops} when is_list(Ops) ->
+            distinct([Key || {Key, _} <- Ops])
+                andalso lists:all(fun(Op) -> is_operation({update, Op}) end, Ops);
+        {remove, {_Key, Type}} ->
+            antidote_crdt:is_type(Type);
+        {remove, Keys} when is_list(Keys) ->
+            distinct(Keys)
+                andalso lists:all(fun(Key) -> is_operation({remove, Key}) end, Keys);
+        {batch, {Updates, Removes}} ->
+            is_list(Updates)
+                andalso is_list(Removes)
+                andalso distinct(Removes ++ [Key || {Key, _} <- Updates])
+                andalso lists:all(fun(Key) -> is_operation({remove, Key}) end, Removes)
+                andalso lists:all(fun(Op) -> is_operation({update, Op}) end, Updates);
+        {reset, {}} -> true;
+        is_bottom -> true;
+        _ ->
+            false
+    end.
 
 distinct([]) -> true;
 distinct([X|Xs]) ->
-  not lists:member(X, Xs) andalso distinct(Xs).
+    not lists:member(X, Xs) andalso distinct(Xs).
 
 is_bottom(Map) ->
-  dict:is_empty(Map).
+    dict:is_empty(Map).
 
 
 %% ===================================================================
@@ -247,131 +247,131 @@ is_bottom(Map) ->
 -ifdef(TEST).
 
 reset1_test() ->
-  Map0 = new(),
-  % DC1: a.incr
-  {ok, Incr1} = downstream({update, {{a, antidote_crdt_counter_fat}, {increment, 1}}}, Map0),
-  {ok, Map1a} = update(Incr1, Map0),
-  % DC1 reset
-  {ok, Reset1} = downstream({reset, {}}, Map1a),
-  {ok, Map1b} = update(Reset1, Map1a),
-  % DC2 a.remove
-  {ok, Remove1} = downstream({remove, {a, antidote_crdt_counter_fat}}, Map0),
-  {ok, Map2a} = update(Remove1, Map0),
-  % DC2 --> DC1
-  {ok, Map1c} = update(Remove1, Map1b),
-  % DC1 reset
-  {ok, Reset2} = downstream({reset, {}}, Map1c),
-  {ok, Map1d} = update(Reset2, Map1c),
-  % DC1: a.incr
-  {ok, Incr2} = downstream({update, {{a, antidote_crdt_counter_fat}, {increment, 2}}}, Map1d),
-  {ok, Map1e} = update(Incr2, Map1d),
+    Map0 = new(),
+    % DC1: a.incr
+    {ok, Incr1} = downstream({update, {{a, antidote_crdt_counter_fat}, {increment, 1}}}, Map0),
+    {ok, Map1a} = update(Incr1, Map0),
+    % DC1 reset
+    {ok, Reset1} = downstream({reset, {}}, Map1a),
+    {ok, Map1b} = update(Reset1, Map1a),
+    % DC2 a.remove
+    {ok, Remove1} = downstream({remove, {a, antidote_crdt_counter_fat}}, Map0),
+    {ok, Map2a} = update(Remove1, Map0),
+    % DC2 --> DC1
+    {ok, Map1c} = update(Remove1, Map1b),
+    % DC1 reset
+    {ok, Reset2} = downstream({reset, {}}, Map1c),
+    {ok, Map1d} = update(Reset2, Map1c),
+    % DC1: a.incr
+    {ok, Incr2} = downstream({update, {{a, antidote_crdt_counter_fat}, {increment, 2}}}, Map1d),
+    {ok, Map1e} = update(Incr2, Map1d),
 
-  io:format("Map0 = ~p~n", [Map0]),
-  io:format("Incr1 = ~p~n", [Incr1]),
-  io:format("Map1a = ~p~n", [Map1a]),
-  io:format("Reset1 = ~p~n", [Reset1]),
-  io:format("Map1b = ~p~n", [Map1b]),
-  io:format("Remove1 = ~p~n", [Remove1]),
-  io:format("Map2a = ~p~n", [Map2a]),
-  io:format("Map1c = ~p~n", [Map1c]),
-  io:format("Reset2 = ~p~n", [Reset2]),
-  io:format("Map1d = ~p~n", [Map1d]),
-  io:format("Incr2 = ~p~n", [Incr2]),
-  io:format("Map1e = ~p~n", [Map1e]),
+    io:format("Map0 = ~p~n", [Map0]),
+    io:format("Incr1 = ~p~n", [Incr1]),
+    io:format("Map1a = ~p~n", [Map1a]),
+    io:format("Reset1 = ~p~n", [Reset1]),
+    io:format("Map1b = ~p~n", [Map1b]),
+    io:format("Remove1 = ~p~n", [Remove1]),
+    io:format("Map2a = ~p~n", [Map2a]),
+    io:format("Map1c = ~p~n", [Map1c]),
+    io:format("Reset2 = ~p~n", [Reset2]),
+    io:format("Map1d = ~p~n", [Map1d]),
+    io:format("Incr2 = ~p~n", [Incr2]),
+    io:format("Map1e = ~p~n", [Map1e]),
 
-  ?assertEqual([], value(Map0)),
-  ?assertEqual([{{a, antidote_crdt_counter_fat}, 1}], value(Map1a)),
-  ?assertEqual([], value(Map1b)),
-  ?assertEqual([], value(Map2a)),
-  ?assertEqual([], value(Map1c)),
-  ?assertEqual([], value(Map1d)),
-  ?assertEqual([{{a, antidote_crdt_counter_fat}, 2}], value(Map1e)).
+    ?assertEqual([], value(Map0)),
+    ?assertEqual([{{a, antidote_crdt_counter_fat}, 1}], value(Map1a)),
+    ?assertEqual([], value(Map1b)),
+    ?assertEqual([], value(Map2a)),
+    ?assertEqual([], value(Map1c)),
+    ?assertEqual([], value(Map1d)),
+    ?assertEqual([{{a, antidote_crdt_counter_fat}, 2}], value(Map1e)).
 
 
 reset2_test() ->
-  Map0 = new(),
-  % DC1: s.add
-  {ok, Add1} = downstream({update, {{s, antidote_crdt_set_rw}, {add, a}}}, Map0),
-  {ok, Map1a} = update(Add1, Map0),
-  % DC1 reset
-  {ok, Reset1} = downstream({reset, {}}, Map1a),
-  {ok, Map1b} = update(Reset1, Map1a),
-  % DC2 s.remove
-  {ok, Remove1} = downstream({remove, {s, antidote_crdt_set_rw}}, Map0),
-  {ok, Map2a} = update(Remove1, Map0),
-  % DC2 --> DC1
-  {ok, Map1c} = update(Remove1, Map1b),
-  % DC1 reset
-  {ok, Reset2} = downstream({reset, {}}, Map1c),
-  {ok, Map1d} = update(Reset2, Map1c),
-  % DC1: s.add
-  {ok, Add2} = downstream({update, {{s, antidote_crdt_set_rw}, {add, b}}}, Map1d),
-  {ok, Map1e} = update(Add2, Map1d),
+    Map0 = new(),
+    % DC1: s.add
+    {ok, Add1} = downstream({update, {{s, antidote_crdt_set_rw}, {add, a}}}, Map0),
+    {ok, Map1a} = update(Add1, Map0),
+    % DC1 reset
+    {ok, Reset1} = downstream({reset, {}}, Map1a),
+    {ok, Map1b} = update(Reset1, Map1a),
+    % DC2 s.remove
+    {ok, Remove1} = downstream({remove, {s, antidote_crdt_set_rw}}, Map0),
+    {ok, Map2a} = update(Remove1, Map0),
+    % DC2 --> DC1
+    {ok, Map1c} = update(Remove1, Map1b),
+    % DC1 reset
+    {ok, Reset2} = downstream({reset, {}}, Map1c),
+    {ok, Map1d} = update(Reset2, Map1c),
+    % DC1: s.add
+    {ok, Add2} = downstream({update, {{s, antidote_crdt_set_rw}, {add, b}}}, Map1d),
+    {ok, Map1e} = update(Add2, Map1d),
 
-  io:format("Map0 = ~p~n"   , [value(Map0)]),
-  io:format("Add1 = ~p~n"   , [Add1]),
-  io:format("Map1a = ~p~n"  , [value(Map1a)]),
-  io:format("Reset1 = ~p~n" , [Reset1]),
-  io:format("Map1b = ~p~n"  , [value(Map1b)]),
-  io:format("Remove1 = ~p~n", [Remove1]),
-  io:format("Map2a = ~p~n"  , [value(Map2a)]),
-  io:format("Map1c = ~p~n"  , [value(Map1c)]),
-  io:format("Reset2 = ~p~n" , [Reset2]),
-  io:format("Map1d = ~p~n"  , [value(Map1d)]),
-  io:format("Add2 = ~p~n"   , [Add2]),
-  io:format("Map1e = ~p~n"  , [value(Map1e)]),
+    io:format("Map0 = ~p~n"   , [value(Map0)]),
+    io:format("Add1 = ~p~n"   , [Add1]),
+    io:format("Map1a = ~p~n"  , [value(Map1a)]),
+    io:format("Reset1 = ~p~n" , [Reset1]),
+    io:format("Map1b = ~p~n"  , [value(Map1b)]),
+    io:format("Remove1 = ~p~n", [Remove1]),
+    io:format("Map2a = ~p~n"  , [value(Map2a)]),
+    io:format("Map1c = ~p~n"  , [value(Map1c)]),
+    io:format("Reset2 = ~p~n" , [Reset2]),
+    io:format("Map1d = ~p~n"  , [value(Map1d)]),
+    io:format("Add2 = ~p~n"   , [Add2]),
+    io:format("Map1e = ~p~n"  , [value(Map1e)]),
 
-  ?assertEqual([], value(Map0)),
-  ?assertEqual([{{s, antidote_crdt_set_rw}, [a]}], value(Map1a)),
-  ?assertEqual([], value(Map1b)),
-  ?assertEqual([], value(Map2a)),
-  ?assertEqual([], value(Map1c)),
-  ?assertEqual([], value(Map1d)),
-  ?assertEqual([{{s, antidote_crdt_set_rw}, [b]}], value(Map1e)).
+    ?assertEqual([], value(Map0)),
+    ?assertEqual([{{s, antidote_crdt_set_rw}, [a]}], value(Map1a)),
+    ?assertEqual([], value(Map1b)),
+    ?assertEqual([], value(Map2a)),
+    ?assertEqual([], value(Map1c)),
+    ?assertEqual([], value(Map1d)),
+    ?assertEqual([{{s, antidote_crdt_set_rw}, [b]}], value(Map1e)).
 
 prop1_test() ->
-  Map0 = new(),
-  % DC1: s.add
-  {ok, Add1} = downstream({update, {{a, antidote_crdt_map_rr}, {update, {{a, antidote_crdt_set_rw}, {add, a}}}}}, Map0),
-  {ok, Map1a} = update(Add1, Map0),
+    Map0 = new(),
+    % DC1: s.add
+    {ok, Add1} = downstream({update, {{a, antidote_crdt_map_rr}, {update, {{a, antidote_crdt_set_rw}, {add, a}}}}}, Map0),
+    {ok, Map1a} = update(Add1, Map0),
 
-  % DC1 reset
-  {ok, Reset1} = downstream({remove, {a, antidote_crdt_map_rr}}, Map1a),
-  {ok, Map1b} = update(Reset1, Map1a),
+    % DC1 reset
+    {ok, Reset1} = downstream({remove, {a, antidote_crdt_map_rr}}, Map1a),
+    {ok, Map1b} = update(Reset1, Map1a),
 
-  io:format("Map0 = ~p~n", [Map0]),
-  io:format("Add1 = ~p~n", [Add1]),
-  io:format("Map1a = ~p~n", [Map1a]),
-  io:format("Reset1 = ~p~n", [Reset1]),
-  io:format("Map1b = ~p~n", [Map1b]),
+    io:format("Map0 = ~p~n", [Map0]),
+    io:format("Add1 = ~p~n", [Add1]),
+    io:format("Map1a = ~p~n", [Map1a]),
+    io:format("Reset1 = ~p~n", [Reset1]),
+    io:format("Map1b = ~p~n", [Map1b]),
 
-  ?assertEqual([], value(Map0)),
-  ?assertEqual([{{a, antidote_crdt_map_rr}, [{{a, antidote_crdt_set_rw}, [a]}]}], value(Map1a)),
-  ?assertEqual([], value(Map1b)).
+    ?assertEqual([], value(Map0)),
+    ?assertEqual([{{a, antidote_crdt_map_rr}, [{{a, antidote_crdt_set_rw}, [a]}]}], value(Map1a)),
+    ?assertEqual([], value(Map1b)).
 
 prop2_test() ->
-  Map0 = new(),
-  % DC1: update remove
-  {ok, Add1} = downstream({update, [{{b, antidote_crdt_map_rr}, {remove, {a, antidote_crdt_set_rw}}}]}, Map0),
-  {ok, Map1a} = update(Add1, Map0),
+    Map0 = new(),
+    % DC1: update remove
+    {ok, Add1} = downstream({update, [{{b, antidote_crdt_map_rr}, {remove, {a, antidote_crdt_set_rw}}}]}, Map0),
+    {ok, Map1a} = update(Add1, Map0),
 
-  % DC2 remove
-  {ok, Remove2} = downstream({remove, {b, antidote_crdt_map_rr}}, Map0),
-  {ok, Map2a} = update(Remove2, Map0),
+    % DC2 remove
+    {ok, Remove2} = downstream({remove, {b, antidote_crdt_map_rr}}, Map0),
+    {ok, Map2a} = update(Remove2, Map0),
 
-  % pull DC2 -> DC1
-  {ok, Map1b} = update(Remove2, Map1a),
+    % pull DC2 -> DC1
+    {ok, Map1b} = update(Remove2, Map1a),
 
-  io:format("Map0 = ~p~n", [Map0]),
-  io:format("Add1 = ~p~n", [Add1]),
-  io:format("Map1a = ~p~n", [Map1a]),
-  io:format("Remove2 = ~p~n", [Remove2]),
-  io:format("Map1b = ~p~n", [Map1b]),
+    io:format("Map0 = ~p~n", [Map0]),
+    io:format("Add1 = ~p~n", [Add1]),
+    io:format("Map1a = ~p~n", [Map1a]),
+    io:format("Remove2 = ~p~n", [Remove2]),
+    io:format("Map1b = ~p~n", [Map1b]),
 
-  ?assertEqual([], value(Map0)),
-  ?assertEqual([], value(Map1a)),
-  ?assertEqual([], value(Map2a)),
-  ?assertEqual([], value(Map1b)).
+    ?assertEqual([], value(Map0)),
+    ?assertEqual([], value(Map1a)),
+    ?assertEqual([], value(Map2a)),
+    ?assertEqual([], value(Map1b)).
 
 upd(Update, State) ->
     {ok, Downstream} = downstream(Update, State),
@@ -379,24 +379,24 @@ upd(Update, State) ->
     Res.
 
 remove_test() ->
-  M1 = new(),
-  ?assertEqual([], value(M1)),
-  ?assertEqual(true, is_bottom(M1)),
-  M2 = upd({update, [
-      {{<<"a">>, antidote_crdt_set_aw}, {add, <<"1">>}},
-      {{<<"b">>, antidote_crdt_register_mv}, {assign, <<"2">>}},
-      {{<<"c">>, antidote_crdt_counter_fat}, {increment, 1}}
+    M1 = new(),
+    ?assertEqual([], value(M1)),
+    ?assertEqual(true, is_bottom(M1)),
+    M2 = upd({update, [
+        {{<<"a">>, antidote_crdt_set_aw}, {add, <<"1">>}},
+        {{<<"b">>, antidote_crdt_register_mv}, {assign, <<"2">>}},
+        {{<<"c">>, antidote_crdt_counter_fat}, {increment, 1}}
     ]}, M1),
-  ?assertEqual([
-      {{<<"a">>, antidote_crdt_set_aw}, [<<"1">>]},
-      {{<<"b">>, antidote_crdt_register_mv}, [<<"2">>]},
-      {{<<"c">>, antidote_crdt_counter_fat}, 1}
-  ], value(M2)),
-  ?assertEqual(false, is_bottom(M2)),
-  M3 = upd({reset, {}}, M2),
-  io:format("M3 state = ~p~n", [dict:to_list(M3)]),
-  ?assertEqual([], value(M3)),
-  ?assertEqual(true, is_bottom(M3)),
-  ok.
+    ?assertEqual([
+        {{<<"a">>, antidote_crdt_set_aw}, [<<"1">>]},
+        {{<<"b">>, antidote_crdt_register_mv}, [<<"2">>]},
+        {{<<"c">>, antidote_crdt_counter_fat}, 1}
+    ], value(M2)),
+    ?assertEqual(false, is_bottom(M2)),
+    M3 = upd({reset, {}}, M2),
+    io:format("M3 state = ~p~n", [dict:to_list(M3)]),
+    ?assertEqual([], value(M3)),
+    ?assertEqual(true, is_bottom(M3)),
+    ok.
 
 -endif.

--- a/src/antidote_crdt_register_lww.erl
+++ b/src/antidote_crdt_register_lww.erl
@@ -56,16 +56,16 @@
 -type antidote_crdt_register_lww_op() :: {assign, term(), non_neg_integer()}  | {assign, term()}.
 
 new() ->
-  {0, <<>>}.
+    {0, <<>>}.
 
 value({_Time, Val}) ->
     Val.
 
 -spec downstream(antidote_crdt_register_lww_op(), antidote_crdt_register_lww()) -> {ok, term()}.
 downstream({assign, Value, Time}, {OldTime, _OldValue}) ->
-  {ok, {max(Time, OldTime + 1), Value}};
+    {ok, {max(Time, OldTime + 1), Value}};
 downstream({assign, Value}, State) ->
-  downstream({assign, Value, make_micro_epoch()}, State).
+    downstream({assign, Value, make_micro_epoch()}, State).
 
 make_micro_epoch() ->
     {Mega, Sec, Micro} = os:timestamp(),
@@ -73,8 +73,8 @@ make_micro_epoch() ->
 
 
 update(Effect, State) ->
-  % take the state with maximum time, if times are equal use maximum state
-  {ok, max(Effect, State)}.
+    % take the state with maximum time, if times are equal use maximum state
+    {ok, max(Effect, State)}.
 
 
 require_state_downstream(_Operation) -> true.
@@ -91,9 +91,13 @@ to_binary(CRDT) ->
     erlang:term_to_binary(CRDT).
 
 from_binary(Bin) ->
-  {ok, erlang:binary_to_term(Bin)}.
+    {ok, erlang:binary_to_term(Bin)}.
 
+%% ===================================================================
+%% EUnit tests
+%% ===================================================================
 -ifdef(test).
+
 all_test() ->
     S0 = new(),
     {ok, Downstream} = downstream({assign, a}, S0),

--- a/src/antidote_crdt_register_mv.erl
+++ b/src/antidote_crdt_register_mv.erl
@@ -89,8 +89,8 @@ downstream({assign, Value}, MVReg) ->
     Overridden = [Tok || {_, Tok} <- MVReg],
     {ok, {Value, Token, Overridden}};
 downstream({reset, {}}, MVReg) ->
-  Overridden = [Tok || {_, Tok} <- MVReg],
-  {ok, {reset, Overridden}}.
+    Overridden = [Tok || {_, Tok} <- MVReg],
+    {ok, {reset, Overridden}}.
 
 -spec unique() -> uniqueToken().
 unique() ->
@@ -104,8 +104,8 @@ update({Value, Token, Overridden}, MVreg) ->
     % insert new value
     {ok, insert_sorted({Value, Token}, MVreg2)};
 update({reset, Overridden}, MVreg) ->
-  MVreg2 = [{V, T} || {V, T} <- MVreg, not lists:member(T, Overridden)],
-  {ok, MVreg2}.
+    MVreg2 = [{V, T} || {V, T} <- MVreg, not lists:member(T, Overridden)],
+    {ok, MVreg2}.
 
 % insert value into sorted list
 insert_sorted(A, []) -> [A];
@@ -163,6 +163,5 @@ reset_test() ->
     R3 = upd({reset, {}}, R2),
     ?assertEqual([], value(R3)),
     ?assertEqual(true, is_bottom(R3)).
-
 
 -endif.

--- a/src/antidote_crdt_set_go.erl
+++ b/src/antidote_crdt_set_go.erl
@@ -62,12 +62,12 @@ value(Set) ->
 
 -spec downstream(antidote_crdt_set_go_op(), antidote_crdt_set_go()) -> {ok, antidote_crdt_set_go_effect()}.
 downstream({add, Elem}, _State) ->
-  {ok, ordsets:from_list([Elem])};
+    {ok, ordsets:from_list([Elem])};
 downstream({add_all, Elems}, _State) ->
-  {ok, ordsets:from_list(Elems)}.
+    {ok, ordsets:from_list(Elems)}.
 
 update(Effect, State) ->
-  {ok, ordsets:union(State, Effect)}.
+    {ok, ordsets:union(State, Effect)}.
 
 require_state_downstream(_Operation) -> false.
 
@@ -82,9 +82,13 @@ to_binary(CRDT) ->
     erlang:term_to_binary(CRDT).
 
 from_binary(Bin) ->
-  {ok, erlang:binary_to_term(Bin)}.
+    {ok, erlang:binary_to_term(Bin)}.
 
+%% ===================================================================
+%% EUnit tests
+%% ===================================================================
 -ifdef(test).
+
 all_test() ->
     S0 = new(),
     {ok, Downstream} = downstream({add, a}, S0),


### PR DESCRIPTION
`antidote` itself uses 4 spaces as identation.
Some parts of `antidote_crdt` have different identations. 
This PR makes them consistent.