### PR TITLE
Updated bcounter to allow operations that have no id() (alias DCID) a…

### DIFF
--- a/src/antidote_crdt_counter_b.erl
+++ b/src/antidote_crdt_counter_b.erl
@@ -71,7 +71,9 @@
 %% An orddict that contains the decrements that were performed on an id.
 -type decrements() :: orddict:orddict(id(), pos_integer()).
 -type antidote_crdt_counter_b() :: {transfers(), decrements()}.
--type antidote_crdt_counter_b_op() :: {increment, {pos_integer(), id()}} | {increment, pos_integer()} | {decrement, {pos_integer(), id()}} | {decrement, pos_integer()} | {transfer, {pos_integer(), id(), id()}} | {transfer, {pos_integer(), id()}}.
+-type antidote_crdt_counter_b_op() :: antidote_crdt_counter_b_partial_op() | antidote_crdt_counter_b_full_op().
+-type antidote_crdt_counter_b_full_op() :: {increment, {pos_integer(), id()}} | {decrement, {pos_integer(), id()}} | {transfer, {pos_integer(), id(), id()}}.
+-type antidote_crdt_counter_b_partial_op() :: {increment, pos_integer()} | {decrement, pos_integer()} | {transfer, {pos_integer(), id()}}.
 -type antidote_crdt_counter_b_effect() :: {{increment, pos_integer()}, id()} | {{decrement, pos_integer()}, id()} | {{transfer, pos_integer(), id()}, id()}.
 
 %% @doc Return a new, empty `antidote_crdt_counter_b()'.

--- a/src/antidote_crdt_counter_b.erl
+++ b/src/antidote_crdt_counter_b.erl
@@ -30,7 +30,8 @@
 %% This counter is able to maintain a non-negative value by
 %% explicitly exchanging permissions to execute decrement operations.
 %% All operations on this CRDT are monotonic and do not keep extra tombstones.
-%% In the code the variable V is used for a positive integer.
+%% In the code the variable V is used for permissions which a positive integer.
+%% The number of total permissions can be 0 but can never be less than 0.
 %% In the code the variable P is used for transfers() which is a defined type.
 %% In the code the variable D is used for decrements() which is a defined type.
 %% @end
@@ -56,28 +57,33 @@
 
 %% API
 -export([localPermissions/2,
+    local_permissions/2,
     permissions/1
 ]).
 
--ifdef(TEST).
--include_lib("eunit/include/eunit.hrl").
--endif.
-
--type id() :: term(). %% A replica's identifier.
--type transfers() :: orddict:orddict({id(), id()}, pos_integer()). %% The orddict that maps
+%% A replica's identifier.
+-type id() :: term().
+%% An orddict that contains permission transfers from one id to the other id. The two ids can be equal which is the representation of an increment.
+-type transfers() :: orddict:orddict({id(), id()}, pos_integer()).
+%% An orddict that contains the decrements that were performed on an id.
 -type decrements() :: orddict:orddict(id(), pos_integer()).
 -type antidote_crdt_counter_b() :: {transfers(), decrements()}.
--type antidote_crdt_counter_b_op() :: {increment | decrement, {pos_integer(), id()}} | {transfer, {pos_integer(), id(), id()}}.
--type antidote_crdt_counter_b_effect() :: {{increment | decrement, pos_integer()} | {transfer, pos_integer(), id()}, id()}.
+-type antidote_crdt_counter_b_op() :: {increment, {pos_integer(), id()}} | {increment, pos_integer()} | {decrement, {pos_integer(), id()}} | {decrement, pos_integer()} | {transfer, {pos_integer(), id(), id()}} | {transfer, {pos_integer(), id()}}.
+-type antidote_crdt_counter_b_effect() :: {{increment, pos_integer()}, id()} | {{decrement, pos_integer()}, id()} | {{transfer, pos_integer(), id()}, id()}.
 
 %% @doc Return a new, empty `antidote_crdt_counter_b()'.
 -spec new() -> antidote_crdt_counter_b().
 new() ->
     {orddict:new(), orddict:new()}.
 
-%% @doc Return the available permissions of replica `Id' in a `antidote_crdt_counter_b()'.
+%% Kept for backwards compatibility.
 -spec localPermissions(id(), antidote_crdt_counter_b()) -> non_neg_integer().
 localPermissions(Id, {P, D}) ->
+    local_permissions(Id, {P, D}).
+
+%% @doc Return the available permissions of replica `Id' in a `antidote_crdt_counter_b()'.
+-spec local_permissions(id(), antidote_crdt_counter_b()) -> non_neg_integer().
+local_permissions(Id, {P, D}) ->
     Received = orddict:fold(
         fun
             (_, V, Acc) ->
@@ -133,24 +139,30 @@ value(Counter) -> Counter.
 %% The first parameter is either `{increment, pos_integer()}' or `{decrement, pos_integer()}',
 %% which specify the operation and amount, or `{transfer, pos_integer(), id()}'
 %% that additionally specifies the target replica.
-%% The second parameter is an `actor()' who identifies the source replica,
+%% The second parameter is an id() who identifies the source replica,
 %% and the third parameter is a `antidote_crdt_counter_b()' which holds the current snapshot.
 %%
 %% Return a tuple containing the operation and source replica.
 %% This operation fails and returns `{error, no_permissions}'
 %% if it tries to consume resources unavailable to the source replica
 %% (which prevents logging of forbidden attempts).
+%% IMPORTANT: The operation is not checked for correctness here!
+%% Using an operation that does not pass the is_operation() check can return invalid results and if applied can break the permissions of the antidote_crdt_counter_b!
 -spec downstream(antidote_crdt_counter_b_op(), antidote_crdt_counter_b()) -> {ok, antidote_crdt_counter_b_effect()} | {error, no_permissions}.
-downstream({increment, {V, Actor}}, _Counter) when is_integer(V), V > 0 ->
-    {ok, {{increment, V}, Actor}};
-downstream({decrement, {V, Actor}}, Counter) when is_integer(V), V > 0 ->
-    generate_downstream_check({decrement, V}, Actor, Counter, V);
-downstream({transfer, {V, ToId, Actor}}, Counter) when is_integer(V), V > 0 ->
-    generate_downstream_check({transfer, V, ToId}, Actor, Counter, V).
+downstream({increment, {V, Id}}, _Counter) ->
+    {ok, {{increment, V}, Id}};
+downstream({decrement, {V, Id}}, Counter) ->
+    generate_downstream_check({decrement, V}, Id, Counter, V);
+downstream({transfer, {V, ToId, FromId}}, Counter) ->
+    generate_downstream_check({transfer, V, ToId}, FromId, Counter, V);
+%%Special case if the client uses an update without ids
+downstream({_, _}, _) ->
+    {error, no_permissions}.
 
-generate_downstream_check(Op, Actor, Counter, V) ->
-    Available = localPermissions(Actor, Counter),
-    if Available >= V -> {ok, {Op, Actor}};
+-spec generate_downstream_check({decrement, pos_integer()} | {transfer, pos_integer(), id()}, id(), antidote_crdt_counter_b(), pos_integer()) -> {ok, antidote_crdt_counter_b_effect()} | {error, no_permissions}.
+generate_downstream_check(PartialEffect, Id, Counter, V) ->
+    Available = local_permissions(Id, Counter),
+    if Available >= V -> {ok, {PartialEffect, Id}};
         Available < V -> {error, no_permissions}
     end.
 
@@ -158,6 +170,8 @@ generate_downstream_check(Op, Actor, Counter, V) ->
 %% usually created with `generate_downstream'.
 %%
 %% Return the resulting `antidote_crdt_counter_b()' after applying the operation.
+%% IMPORTANT: The downstream effect is not checked for correctness here!
+%% Using a downstream effect that is invalid can break the permissions of the antidote_crdt_counter_b!
 -spec update(antidote_crdt_counter_b_effect(), antidote_crdt_counter_b()) -> {ok, antidote_crdt_counter_b()}.
 update({{increment, V}, Id}, Counter) ->
     increment(Id, V, Counter);
@@ -192,9 +206,12 @@ from_binary(<<B/binary>>) -> {ok, binary_to_term(B)}.
 %% @doc The following operation verifies
 %%      that Operation is supported by this particular CRDT.
 -spec is_operation(term()) -> boolean().
-is_operation({increment, {V, _Actor}}) -> is_pos_integer(V);
-is_operation({decrement, {V, _Actor}}) -> is_pos_integer(V);
-is_operation({transfer, {V, _, _Actor}}) -> is_pos_integer(V);
+is_operation({increment, {V, _Id}}) -> is_pos_integer(V);
+is_operation({decrement, {V, _Id}}) -> is_pos_integer(V);
+is_operation({transfer, {V, _ToId, _FromId}}) -> is_pos_integer(V);
+is_operation({increment, V}) -> is_pos_integer(V);
+is_operation({decrement, V}) -> is_pos_integer(V);
+is_operation({transfer, {V, _ToId}}) -> is_pos_integer(V);
 is_operation(_) -> false.
 
 -spec is_pos_integer(term()) -> boolean().
@@ -202,7 +219,7 @@ is_pos_integer(V) -> is_integer(V) andalso (V > 0).
 
 %% The antidote_crdt_counter_b requires no state downstream for increment.
 -spec require_state_downstream(antidote_crdt_counter_b_op()) -> boolean().
-require_state_downstream({increment, {_, _}}) ->
+require_state_downstream({increment, _}) ->
     false;
 require_state_downstream(_) ->
     true.
@@ -220,6 +237,8 @@ equal(BCounter1, BCounter2) ->
 
 -ifdef(TEST).
 
+-include_lib("eunit/include/eunit.hrl").
+
 %% Utility to generate and apply downstream operations.
 apply_op(Op, Counter) ->
     {ok, OP_DS} = downstream(Op, Counter),
@@ -236,19 +255,20 @@ increment_test() ->
     Counter1 = apply_op({increment, {10, r1}}, Counter0),
     Counter2 = apply_op({increment, {5, r2}}, Counter1),
     %% Test replicas' values.
-    ?assertEqual(5, localPermissions(r2, Counter2)),
-    ?assertEqual(10, localPermissions(r1, Counter2)),
+    ?assertEqual(5, local_permissions(r2, Counter2)),
+    ?assertEqual(10, local_permissions(r1, Counter2)),
     %% Test total value.
     ?assertEqual(15, permissions(Counter2)).
 
-%% Tests the function `localPermissions()'.
-localPermisisons_test() ->
+%% Tests the function `local_permissions()'.
+local_permissions_test() ->
     Counter0 = new(),
     Counter1 = apply_op({increment, {10, r1}}, Counter0),
     %% Test replica with positive amount of permissions.
-    ?assertEqual(10, localPermissions(r1, Counter1)),
+    ?assertEqual(10, local_permissions(r1, Counter1)),
     %% Test nonexistent replica.
-    ?assertEqual(0, localPermissions(r2, Counter1)).
+    ?assertEqual(0, local_permissions(r2, Counter1)),
+    ?assertEqual(10, permissions(Counter1)).
 
 %% Tests decrement operations.
 decrement_test() ->
@@ -258,7 +278,8 @@ decrement_test() ->
     Counter2 = apply_op({decrement, {6, r1}}, Counter1),
     ?assertEqual(4, permissions(Counter2)),
     %% Test nonexistent replica.
-    ?assertEqual(0, localPermissions(r2, Counter1)),
+    ?assertEqual(0, local_permissions(r2, Counter1)),
+    ?assertEqual(0, local_permissions(r2, Counter2)),
     %% Test forbidden decrement.
     OP_DS = downstream({decrement, {6, r1}}, Counter2),
     ?assertEqual({error, no_permissions}, OP_DS).
@@ -284,17 +305,29 @@ transfer_test() ->
     Counter1 = apply_op({increment, {10, r1}}, Counter0),
     %% Test transferring permissions from one replica to another.
     Counter2 = apply_op({transfer, {6, r2, r1}}, Counter1),
-    ?assertEqual(4, localPermissions(r1, Counter2)),
-    ?assertEqual(6, localPermissions(r2, Counter2)),
+    ?assertEqual(4, local_permissions(r1, Counter2)),
+    ?assertEqual(6, local_permissions(r2, Counter2)),
     ?assertEqual(10, permissions(Counter2)),
-    %% Test transference forbidden by lack of previously transfered resources.
+    %% Test transference forbidden by lack of previously transferred resources.
     OP_DS = downstream({transfer, {5, r2, r1}}, Counter2),
     ?assertEqual({error, no_permissions}, OP_DS),
-    %% Test transference enabled by previously transfered resources.
+    %% Test transference enabled by previously transferred resources.
     Counter3 = apply_op({transfer, {5, r1, r2}}, Counter2),
-    ?assertEqual(9, localPermissions(r1, Counter3)),
-    ?assertEqual(1, localPermissions(r2, Counter3)),
+    ?assertEqual(9, local_permissions(r1, Counter3)),
+    ?assertEqual(1, local_permissions(r2, Counter3)),
     ?assertEqual(10, permissions(Counter3)).
+
+operation_without_id_test() ->
+    Counter0 = new(),
+    IncrementOp = {increment, 5},
+    DecrementOp = {decrement, 5},
+    TransferOp = {transfer, {5, dcid}},
+    ?assertEqual(true, is_operation(IncrementOp)),
+    ?assertEqual(true, is_operation(DecrementOp)),
+    ?assertEqual(true, is_operation(TransferOp)),
+    ?assertEqual({error, no_permissions}, downstream(IncrementOp, Counter0)),
+    ?assertEqual({error, no_permissions}, downstream(DecrementOp, Counter0)),
+    ?assertEqual({error, no_permissions}, downstream(TransferOp, Counter0)).
 
 %% Tests the function `value()'.
 value_test() ->
@@ -327,16 +360,25 @@ binary_test() ->
     Counter1 = apply_op({increment, {10, r1}}, Counter0),
     Counter2 = apply_op({decrement, {6, r1}}, Counter1),
     Counter3 = apply_op({transfer, {2, r2, r1}}, Counter2),
-    %% Assert marshaling and unmarshaling holds the same `antidote_crdt_counter_b()'.
+    %% Assert marshalling and unmarshalling holds the same `antidote_crdt_counter_b()'.
     B = to_binary(Counter3),
     ?assertEqual({ok, Counter3}, from_binary(B)).
 
 %% Tests that operations are correctly detected.
 is_operation_test() ->
     ?assertEqual(true, is_operation({transfer, {2, r2, r1}})),
+    ?assertEqual(false, is_operation({transfer, {-2, r2, r1}})),
+    ?assertEqual(false, is_operation({transfer, {0, r2, r1}})),
+    ?assertEqual(true, is_operation({transfer, {2, r2}})),
+    ?assertEqual(false, is_operation({transfer, {-2, r2}})),
+    ?assertEqual(false, is_operation({transfer, 2})),
     ?assertEqual(true, is_operation({increment, {50, r1}})),
+    ?assertEqual(false, is_operation({increment, {-50, r1}})),
+    ?assertEqual(true, is_operation({increment, 50})),
+    ?assertEqual(false, is_operation({increment, -50})),
     ?assertEqual(false, is_operation(increment)),
     ?assertEqual(true, is_operation({decrement, {50, r1}})),
+    ?assertEqual(true, is_operation({decrement, 50})),
     ?assertEqual(false, is_operation(decrement)),
     ?assertEqual(false, is_operation({anything, [1, 2, 3]})).
 

--- a/src/antidote_crdt_counter_b.erl
+++ b/src/antidote_crdt_counter_b.erl
@@ -383,4 +383,27 @@ is_operation_test() ->
     ?assertEqual(false, is_operation(decrement)),
     ?assertEqual(false, is_operation({anything, [1, 2, 3]})).
 
+%% Tests that operations are only valid with a positive integer.
+is_operation_only_pos_integer_test() ->
+    ?assertEqual(true, is_operation({increment, {1, r1}})),
+    ?assertEqual(false, is_operation({increment, {0, r1}})),
+    ?assertEqual(false, is_operation({increment, {-1, r1}})),
+    ?assertEqual(true, is_operation({increment, 1})),
+    ?assertEqual(false, is_operation({increment, 0})),
+    ?assertEqual(false, is_operation({increment, -1})),
+
+    ?assertEqual(true, is_operation({decrement, {1, r1}})),
+    ?assertEqual(false, is_operation({decrement, {0, r1}})),
+    ?assertEqual(false, is_operation({decrement, {-1, r1}})),
+    ?assertEqual(true, is_operation({decrement, 1})),
+    ?assertEqual(false, is_operation({decrement, 0})),
+    ?assertEqual(false, is_operation({decrement, -1})),
+
+    ?assertEqual(true, is_operation({transfer, {1, r2, r1}})),
+    ?assertEqual(false, is_operation({transfer, {0, r2, r1}})),
+    ?assertEqual(false, is_operation({transfer, {-1, r2, r1}})),
+    ?assertEqual(true, is_operation({transfer, {1, r2}})),
+    ?assertEqual(false, is_operation({transfer, {0, r2}})),
+    ?assertEqual(false, is_operation({transfer, {-1, r2}})).
+
 -endif.

--- a/src/antidote_crdt_counter_b.erl
+++ b/src/antidote_crdt_counter_b.erl
@@ -41,6 +41,9 @@
 -behaviour(antidote_crdt).
 
 -include("antidote_crdt.hrl").
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
 
 %% Call backs
 -export([new/0,
@@ -236,8 +239,6 @@ equal(BCounter1, BCounter2) ->
 %% ===================================================================
 
 -ifdef(TEST).
-
--include_lib("eunit/include/eunit.hrl").
 
 %% Utility to generate and apply downstream operations.
 apply_op(Op, Counter) ->

--- a/test/prop_counter_b.erl
+++ b/test/prop_counter_b.erl
@@ -1,0 +1,102 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright <2013-2018> <
+%%  Technische Universität Kaiserslautern, Germany
+%%  Université Pierre et Marie Curie / Sorbonne-Université, France
+%%  Universidade NOVA de Lisboa, Portugal
+%%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
+%% >
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either expressed or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% List of the contributors to the development of Antidote: see AUTHORS file.
+%% Description and complete License: see LICENSE file.
+%% -------------------------------------------------------------------
+
+-module(prop_counter_b).
+
+-define(PROPER_NO_TRANS, true).
+-include_lib("proper/include/proper.hrl").
+
+%% API
+-export([prop_is_operation_test/0, prop_is_not_operation_test/0, prop_increment_decrement_test/0]).
+
+
+%%%%%%%%%%%%%%%%%%
+%%% Properties %%%
+%%%%%%%%%%%%%%%%%%
+
+prop_is_operation_test() ->
+    ?FORALL(Operation, valid_operations(),
+        begin
+            antidote_crdt_counter_b:is_operation(Operation)
+        end).
+
+prop_is_not_operation_test() ->
+    ?FORALL(Operation, invalid_negative_operations(),
+        begin
+            not antidote_crdt_counter_b:is_operation(Operation)
+        end).
+
+prop_increment_decrement_test() ->
+    proper:forall(get_increment_decrement_ops(),
+        fun(OpType) ->
+            {IncrementOp = {increment, {IncrementValue, undefined}}, DecrementOp = {decrement, {DecrementValue, undefined}}} = OpType,
+            Counter1 = antidote_crdt_counter_b:new(),
+            true = antidote_crdt_counter_b:is_operation(IncrementOp),
+            true = antidote_crdt_counter_b:is_operation(DecrementOp),
+            {error, no_permissions} = antidote_crdt_counter_b:downstream(DecrementOp, Counter1),
+            {ok, IncrementEffect} = antidote_crdt_counter_b:downstream(IncrementOp, Counter1),
+            {ok, Counter2} = antidote_crdt_counter_b:update(IncrementEffect, Counter1),
+            DecrementEffectResult = antidote_crdt_counter_b:downstream(DecrementOp, Counter2),
+            case IncrementValue >= DecrementValue of
+                true ->
+                    {ok, DecrementEffect} = DecrementEffectResult,
+                    {ok, Counter3} = antidote_crdt_counter_b:update(DecrementEffect, Counter2),
+                    CorrectPermissions = IncrementValue - DecrementValue,
+                    TotalPermissions = antidote_crdt_counter_b:permissions(Counter3),
+                    LocalPermissions = antidote_crdt_counter_b:local_permissions(undefined, Counter3),
+                    true = CorrectPermissions == TotalPermissions,
+                    true = TotalPermissions == LocalPermissions;
+                false ->
+                    {error, no_permissions} == DecrementEffectResult
+            end
+        end).
+
+%%%%%%%%%%%%%%%
+%%% Helpers %%%
+%%%%%%%%%%%%%%%
+
+%%%%%%%%%%%%%%%%%%
+%%% Generators %%%
+%%%%%%%%%%%%%%%%%%
+
+valid_operations() ->
+    oneof(
+        [
+            {oneof([increment, decrement]), oneof([pos_integer(), {pos_integer(), term()}])},
+            {transfer, oneof([{pos_integer(), term()}, {pos_integer(), term(), term()}])}
+        ]).
+
+invalid_negative_operations() ->
+    oneof(
+        [
+            {oneof([increment, decrement]), oneof([oneof([neg_integer(), 0]), {oneof([neg_integer(), 0]), term()}])},
+            {transfer, oneof([{oneof([neg_integer(), 0]), term()}, {oneof([neg_integer(), 0]), term(), term()}])}
+        ]).
+
+get_increment_decrement_ops() ->
+    {{increment, {pos_integer(), undefined}}, {decrement, {pos_integer(), undefined}}}.


### PR DESCRIPTION
…nd added proper test module

Operations that have no id() will be rejected from the downstream function with {error, no_permissions}
This is mainly intended to allow bcounter operations to pass the initial antidote operation check and another module (bcounter_mgr) makes sure that operations get an id() added
Additionally more tests were added and preliminary proper tests for counter_b were added
Also added some more documentation

This builds upon what has been proposed in PR #29 by @SmallEndian and extends it to all updates in the antidote_crdt_counter_b