### PR TITLE
Add support for secure CRDTs

### DIFF
--- a/src/antidote_crdt.erl
+++ b/src/antidote_crdt.erl
@@ -59,6 +59,7 @@
 antidote_crdt_counter_pn
 | antidote_crdt_counter_b
 | antidote_crdt_counter_fat
+| antidote_crdt_secure_counter_pn
 | antidote_crdt_flag_ew
 | antidote_crdt_flag_dw
 | antidote_crdt_set_go
@@ -88,19 +89,20 @@ antidote_crdt_counter_pn
 
 % Check if the given type is supported by Antidote
 -spec is_type(typ()) -> boolean().
-is_type(antidote_crdt_counter_pn)   -> true;
-is_type(antidote_crdt_counter_b)    -> true;
-is_type(antidote_crdt_counter_fat)  -> true;
-is_type(antidote_crdt_flag_ew)      -> true;
-is_type(antidote_crdt_flag_dw)      -> true;
-is_type(antidote_crdt_set_go)       -> true;
-is_type(antidote_crdt_set_aw)       -> true;
-is_type(antidote_crdt_set_rw)       -> true;
-is_type(antidote_crdt_register_lww) -> true;
-is_type(antidote_crdt_register_mv)  -> true;
-is_type(antidote_crdt_map_go)       -> true;
-is_type(antidote_crdt_map_rr)       -> true;
-is_type(_)                          -> false.
+is_type(antidote_crdt_counter_pn)        -> true;
+is_type(antidote_crdt_counter_b)         -> true;
+is_type(antidote_crdt_counter_fat)       -> true;
+is_type(antidote_crdt_secure_counter_pn) -> true;
+is_type(antidote_crdt_flag_ew)           -> true;
+is_type(antidote_crdt_flag_dw)           -> true;
+is_type(antidote_crdt_set_go)            -> true;
+is_type(antidote_crdt_set_aw)            -> true;
+is_type(antidote_crdt_set_rw)            -> true;
+is_type(antidote_crdt_register_lww)      -> true;
+is_type(antidote_crdt_register_mv)       -> true;
+is_type(antidote_crdt_map_go)            -> true;
+is_type(antidote_crdt_map_rr)            -> true;
+is_type(_)                               -> false.
 
 
 % Returns the initial CRDT state for the given Type

--- a/src/antidote_crdt_map_go.erl
+++ b/src/antidote_crdt_map_go.erl
@@ -62,9 +62,7 @@ new() ->
 
 -spec value(antidote_crdt_map_go()) -> [{{Key::term(), Type::atom()}, Value::term()}].
 value(Map) ->
-    lists:sort([
-        {{Key, Type}, (antidote_crdt:alias(Type)):value(Value)} || {{Key, Type}, Value} <- dict:to_list(Map)
-    ]).
+    lists:sort([{{Key, Type}, antidote_crdt:value(Type, Value)} || {{Key, Type}, Value} <- dict:to_list(Map)]).
 
 -spec require_state_downstream(antidote_crdt_map_go_op()) -> boolean().
 require_state_downstream(_Op) ->
@@ -73,24 +71,22 @@ require_state_downstream(_Op) ->
 
 -spec downstream(antidote_crdt_map_go_op(), antidote_crdt_map_go()) -> {ok, antidote_crdt_map_go_effect()}.
 downstream({update, {{Key, Type}, Op}}, CurrentMap) ->
-    T = antidote_crdt:alias(Type),
     % TODO could be optimized for some types
     CurrentValue = case dict:is_key({Key, Type}, CurrentMap) of
         true -> dict:fetch({Key, Type}, CurrentMap);
-        false -> T:new()
+        false -> antidote_crdt:new(Type)
     end,
-    {ok, DownstreamOp} = T:downstream(Op, CurrentValue),
+    {ok, DownstreamOp} = antidote_crdt:downstream(Type, Op, CurrentValue),
     {ok, {update, {{Key, Type}, DownstreamOp}}};
 downstream({update, Ops}, CurrentMap) when is_list(Ops) ->
     {ok, {update, lists:map(fun(Op) -> {ok, DSOp} = downstream({update, Op}, CurrentMap), DSOp end, Ops)}}.
 
 -spec update(antidote_crdt_map_go_effect(), antidote_crdt_map_go()) -> {ok, antidote_crdt_map_go()}.
 update({update, {{Key, Type}, Op}}, Map) ->
-    T = antidote_crdt:alias(Type),
     case dict:is_key({Key, Type}, Map) of
-        true -> {ok, dict:update({Key, Type}, fun(V) -> {ok, Value} = T:update(Op, V), Value end, Map)};
-        false -> NewValue = T:new(),
-                 {ok, NewValueUpdated} = T:update(Op, NewValue),
+        true -> {ok, dict:update({Key, Type}, fun(V) -> {ok, Value} = antidote_crdt:update(Type, Op, V), Value end, Map)};
+        false -> NewValue = antidote_crdt:new(Type),
+                 {ok, NewValueUpdated} = antidote_crdt:update(Type, Op, NewValue),
                  {ok, dict:store({Key, Type}, NewValueUpdated, Map)}
     end;
 update({update, Ops}, Map) ->
@@ -122,8 +118,7 @@ from_binary(<<?TAG:8/integer, ?V1_VERS:8/integer, Bin/binary>>) ->
 is_operation(Operation) ->
     case Operation of
         {update, {{_Key, Type}, Op}} ->
-            T = antidote_crdt:alias(Type),
-            antidote_crdt:is_type(Type) andalso T:is_operation(Op);
+            antidote_crdt:is_type(Type) andalso antidote_crdt:is_operation(Type, Op);
         {update, Ops} when is_list(Ops) ->
             distinct([Key || {Key, _} <- Ops])
                 andalso lists:all(fun(Op) -> is_operation({update, Op}) end, Ops);

--- a/src/antidote_crdt_map_rr.erl
+++ b/src/antidote_crdt_map_rr.erl
@@ -87,15 +87,16 @@ new() ->
 
 -spec value(state()) -> value().
 value(Map) ->
-    lists:sort([{{Key, Type}, Type:value(Value)} || {{Key, Type}, Value} <- dict:to_list(Map)]).
+    lists:sort([{{Key, Type}, (antidote_crdt:alias(Type)):value(Value)} || {{Key, Type}, Value} <- dict:to_list(Map)]).
 
 % get a value from the map
 % returns empty value if the key is not present in the map
 -spec get(typedKey(), value()) -> term().
 get({_K, Type}=Key, Map) ->
+    T = antidote_crdt:alias(Type),
     case orddict:find(Key, Map) of
         {ok, Val} -> Val;
-        error -> Type:value(Type:new())
+        error -> T:value(T:new())
     end.
 
 
@@ -124,26 +125,28 @@ downstream({reset, {}}, CurrentMap) ->
 
 -spec generate_downstream_update({typedKey(), Op::term()}, state()) -> nested_downstream().
 generate_downstream_update({{Key, Type}, Op}, CurrentMap) ->
+    T = antidote_crdt:alias(Type),
     CurrentState =
         case dict:is_key({Key, Type}, CurrentMap) of
             true -> dict:fetch({Key, Type}, CurrentMap);
-            false -> Type:new()
+            false -> T:new()
         end,
-    {ok, DownstreamEffect} = Type:downstream(Op, CurrentState),
+    {ok, DownstreamEffect} = T:downstream(Op, CurrentState),
     {{Key, Type}, {ok, DownstreamEffect}}.
 
 
 -spec generate_downstream_remove(typedKey(), state()) -> nested_downstream().
 generate_downstream_remove({Key, Type}, CurrentMap) ->
+    T = antidote_crdt:alias(Type),
     CurrentState =
         case dict:is_key({Key, Type}, CurrentMap) of
             true -> dict:fetch({Key, Type}, CurrentMap);
-            false -> Type:new()
+            false -> T:new()
         end,
     DownstreamEffect =
-        case Type:is_operation({reset, {}}) of
+        case T:is_operation({reset, {}}) of
             true ->
-                {ok, _} = Type:downstream({reset, {}}, CurrentState);
+                {ok, _} = T:downstream({reset, {}}, CurrentState);
             false ->
                 none
         end,
@@ -158,20 +161,22 @@ update({Updates, Removes}, State) ->
     {ok, State4}.
 
 update_entry({{Key, Type}, {ok, Op}}, Map) ->
+    T = antidote_crdt:alias(Type),
     case dict:find({Key, Type}, Map) of
         {ok, State} ->
-            {ok, UpdatedState} = Type:update(Op, State),
+            {ok, UpdatedState} = T:update(Op, State),
             dict:store({Key, Type}, UpdatedState, Map);
         error ->
-            NewValue = Type:new(),
-            {ok, NewValueUpdated} = Type:update(Op, NewValue),
+            NewValue = T:new(),
+            {ok, NewValueUpdated} = T:update(Op, NewValue),
             dict:store({Key, Type}, NewValueUpdated, Map)
     end.
 
 remove_entry({{Key, Type}, {ok, Op}}, Map) ->
+    T = antidote_crdt:alias(Type),
     case dict:find({Key, Type}, Map) of
         {ok, State} ->
-            {ok, UpdatedState} = Type:update(Op, State),
+            {ok, UpdatedState} = T:update(Op, State),
             case is_bottom(Type, UpdatedState) of
                 true ->
                     dict:erase({Key, Type}, Map);
@@ -193,7 +198,8 @@ remove_obsolete({Key, Type}, Val, Map) ->
     end.
 
 is_bottom(Type, State) ->
-    erlang:function_exported(Type, is_bottom, 1) andalso Type:is_bottom(State).
+    T = antidote_crdt:alias(Type),
+    erlang:function_exported(T, is_bottom, 1) andalso T:is_bottom(State).
 
 equal(Map1, Map2) ->
     Map1 == Map2. % TODO better implementation (recursive equals)
@@ -211,8 +217,8 @@ from_binary(<<?TAG:8/integer, ?V1_VERS:8/integer, Bin/binary>>) ->
 is_operation(Operation) ->
     case Operation of
         {update, {{_Key, Type}, Op}} ->
-            antidote_crdt:is_type(Type)
-                andalso Type:is_operation(Op);
+            T = antidote_crdt:alias(Type),
+            antidote_crdt:is_type(Type) andalso T:is_operation(Op);
         {update, Ops} when is_list(Ops) ->
             distinct([Key || {Key, _} <- Ops])
                 andalso lists:all(fun(Op) -> is_operation({update, Op}) end, Ops);

--- a/src/antidote_crdt_secure_counter_pn.erl
+++ b/src/antidote_crdt_secure_counter_pn.erl
@@ -50,55 +50,57 @@
 
 -type freshness() :: fresh | spoiled.
 -type delta() :: integer().
--type nsquare() :: integer().
--type state() :: {freshness(), integer(), nsquare()}.
--type op() :: {increment, delta()} | {increment, {delta(), nsquare()}}.
--type effect() :: delta() | {delta(), nsquare()}.
+-type nsquare() :: pos_integer().
+-type state() :: {freshness(), integer()}.
+-type op() :: {increment, {delta(), nsquare()}}.
+-type effect() :: {delta(), nsquare()}.
 
-%% @doc Create a new, empty 'antidote_crdt_secure_counter_pn'
+%% @doc Create a new, empty 'antidote_crdt_secure_counter_pn'.
+%%
+%% The first element of the state tuple indicates whether the counter
+%% is newly created (no increments done yet) or not. The second element
+%% represents the encrypted (as specified by the Paillier scheme) total
+%% value of the counter.
 -spec new() -> state().
 new() ->
-    {fresh, 0, 0}.
+    {fresh, 0}.
 
-%% @doc The single, total value of a secure pn-counter.
+%% @doc Returns the encrypted (as specified by the Paillier scheme) total
+%% value of a secure pn-counter.
 -spec value(state()) -> integer().
-value({_, Value, _}) when is_integer(Value) ->
+value({_, Value}) when is_integer(Value) ->
     Value.
 
 %% @doc Generate a downstream operation.
-%% The first parameter is either a tuple of the form `{increment, integer()}'
-%% or a tuple of the form `{increment, {integer(), integer()}}'. The first
-%% integer represents the delta value by which the counter will be incremented,
-%% while the second integer is the n squared value used by the Paillier
-%% cryptosystem. The second parameter is the secure pn-counter, this parameter
-%% is not actually used.
--spec downstream(op(), state()) -> {ok, effect()}.
-downstream({increment, {Delta, NSquare}}, _SecurePNCounter)
-    when is_integer(Delta) and is_integer(Delta)
-->
-    {ok, {Delta, NSquare}};
-downstream({increment, Delta}, _SecurePNCounter) when is_integer(Delta) ->
-    {ok, Delta}.
-
-%% @doc Updates a given secure pn-counter, incrementing it by a given `Delta'.
-%% By incrementing we mean performing the homomorphic addition of the counter
-%% value with the given delta. As described by the Paillier cryptosystem, the
-%% homomorphic addition of plaintexts translates to the product of two
-%% ciphertexts modulo n squared.
 %%
-%% A value for `NSquare` may also be provided, if it isn't, the one in the
-%% counter state will be used.
+%% The first parameter is a tuple of the form `{increment, {integer(), pos_integer()}}`.
+%% Where the first integer represents the encrypted delta value by which the counter
+%% will be incremented. The second integer represents the N squared value calculated
+%% during the key generation phase of the Paillier cryptosystem.
+%%
+%% The value of N is part of the user's public key, it is ok for the server to know this
+%% value. Invalid `NSquare` values (less than or equal to zero) are rejected, and a
+%% downstream effect is not generated.
+%%
+%% The second parameter is the secure pn-counter, this parameter is not actually used.
+-spec downstream(op(), state()) -> {ok, effect()}.
+downstream({increment, {Delta, NSquare}}, _SecurePNCounter) when
+    is_integer(Delta) and is_integer(NSquare) and (NSquare > 0)
+->
+    {ok, {Delta, NSquare}}.
+
+%% @doc Updates a given secure pn-counter, incrementing it by a given
+%% encrypted `Delta'. By incrementing we mean performing the homomorphic
+%% addition of the counter value with the given delta. As described by
+%% the Paillier cryptosystem, the homomorphic addition of two plaintexts
+%% translates to the product of two ciphertexts modulo N squared.
 %%
 %% Returns the updated secure pn-counter.
 -spec update(effect(), state()) -> {ok, state()}.
-update({Delta, NSquare}, {fresh, _, _}) ->
-    {ok, {spoiled, Delta, NSquare}};
-update({Delta, NSquare}, {spoiled, Value, _}) ->
-    {ok, {spoiled, (Value * Delta) rem NSquare, NSquare}};
-update(Delta, {fresh, _, NSquare}) ->
-    {ok, {spoiled, Delta, NSquare}};
-update(Delta, {spoiled, Value, NSquare}) ->
-    {ok, {spoiled, (Value * Delta) rem NSquare, NSquare}}.
+update({Delta, _NSquare}, {fresh, _Value}) ->
+    {ok, {spoiled, Delta}};
+update({Delta, NSquare}, {spoiled, Value}) ->
+    {ok, {spoiled, (Value * Delta) rem NSquare}}.
 
 %% @doc Compare if two secure counters are equal.
 -spec equal(state(), state()) -> boolean().
@@ -116,9 +118,12 @@ from_binary(Bin) ->
 %% @doc The following function verifies that a given operation is supported by
 %% this particular CRDT.
 -spec is_operation(term()) -> boolean().
-is_operation({increment, {Delta, NSquare}}) when is_integer(Delta) and is_integer(NSquare) -> true;
-is_operation({increment, Delta}) when is_integer(Delta) -> true;
-is_operation(_) -> false.
+is_operation({increment, {Delta, NSquare}}) when
+    is_integer(Delta) and is_integer(NSquare) and (NSquare > 0)
+->
+    true;
+is_operation(_) ->
+    false.
 
 %% @doc Returns true if ?MODULE:downstream/2 needs the state of crdt
 %% to generate downstream effect.
@@ -136,33 +141,46 @@ prepare_and_effect(Op, PNCounter) ->
     update(Downstream, PNCounter).
 
 new_test() ->
-    ?assertEqual({fresh, 0, 0}, new()).
+    ?assertEqual({fresh, 0}, new()).
 
 value_test() ->
-    ?assertEqual(3, value({fresh, 3, 2})),
-    ?assertEqual(4, value({spoiled, 4, 2})).
+    ?assertEqual(0, value({fresh, 0})),
+    ?assertEqual(4, value({spoiled, 4})).
 
-%% @doc Tests wether the secure pn-counter is correctly updated.
+%% @doc Tests whether the secure pn-counter is correctly updated.
 update_test() ->
     Counter = new(),
-    % Fresh counter without a given n squared.
-    {ok, Counter1} = prepare_and_effect({increment, 1}, Counter),
-    ?assertEqual({spoiled, 1, 0}, Counter1),
-    % Fresh counter with a given n squared.
-    {ok, Counter2} = prepare_and_effect({increment, {1, 1}}, Counter),
-    ?assertEqual({spoiled, 1, 1}, Counter2),
-    % Spoiled counter.
-    {ok, Counter3} = prepare_and_effect({increment, 2}, Counter2),
-    ?assertEqual({spoiled, 0, 1}, Counter3),
-    {ok, Counter4} = prepare_and_effect({increment, {2, 3}}, Counter2),
-    ?assertEqual({spoiled, 2, 3}, Counter4).
+    % Fresh counter becomes spoiled.
+    {ok, Counter1} = prepare_and_effect({increment, {2, 1}}, Counter),
+    ?assertEqual({spoiled, 2}, Counter1),
+    % Spoiled counter stays spoiled and correctly updates value.
+    {ok, Counter2} = prepare_and_effect({increment, {3, 36}}, Counter1),
+    ?assertEqual({spoiled, 6}, Counter2).
+
+%% @doc Updates should only accept positive N square values.
+reject_invalid_nsquare_test() ->
+    Counter = new(),
+    Operation1 = {increment, {1,  0}},
+    Operation2 = {increment, {1, -1}},
+    ?assertNot(is_operation(Operation1)),
+    ?assertNot(is_operation(Operation2)),
+    ?assertError(function_clause, downstream(Operation1, Counter)),
+    ?assertError(function_clause, downstream(Operation2, Counter)).
 
 equal_test() ->
-    Counter1 = {fresh, 4, 0},
-    Counter2 = {fresh, 2, 0},
-    Counter3 = {fresh, 2, 0},
+    Counter1 = {fresh, 4},
+    Counter2 = {fresh, 2},
+    Counter3 = {fresh, 2},
     ?assertNot(equal(Counter1, Counter2)),
-    ?assert(equal(Counter2, Counter3)).
+    ?assert(equal(Counter2, Counter3)),
+
+    Counter4 = {spoiled, 5},
+    Counter5 = {spoiled, 3},
+    Counter6 = {spoiled, 3},
+    ?assertNot(equal(Counter4, Counter5)),
+    ?assert(equal(Counter5, Counter6)),
+
+    ?assertNot(equal(Counter1, Counter4)).
 
 binary_test() ->
     Counter1 = {spoiled, 4, 5},

--- a/src/antidote_crdt_secure_counter_pn.erl
+++ b/src/antidote_crdt_secure_counter_pn.erl
@@ -1,0 +1,173 @@
+%% -------------------------------------------------------------------
+%% Copyright <2020> <
+%%  Technische Universität Kaiserslautern, Germany
+%%  Université Pierre et Marie Curie / Sorbonne-Université, France
+%%  Universidade NOVA de Lisboa, Portugal
+%%  Université catholique de Louvain (UCL), Belgique
+%%  INESC TEC, Portugal
+%% >
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either expressed or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% List of the contributors to the development of Antidote: see AUTHORS file.
+%% Description and complete License: see LICENSE file.
+%% -------------------------------------------------------------------
+
+%% antidote_crdt_secure_counter_pn: A convergent, replicated, operation
+%% based secure (using the Paillier cryptosystem) PN-Counter.
+
+-module(antidote_crdt_secure_counter_pn).
+
+-behaviour(antidote_crdt).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+-export([
+    new/0,
+    value/1,
+    downstream/2,
+    update/2,
+    equal/2,
+    to_binary/1,
+    from_binary/1,
+    is_operation/1,
+    require_state_downstream/1
+]).
+
+-type freshness() :: fresh | spoiled.
+-type delta() :: integer().
+-type nsquare() :: integer().
+-type state() :: {freshness(), integer(), nsquare()}.
+-type op() :: {increment, delta()} | {increment, {delta(), nsquare()}}.
+-type effect() :: delta() | {delta(), nsquare()}.
+
+%% @doc Create a new, empty 'antidote_crdt_secure_counter_pn'
+-spec new() -> state().
+new() ->
+    {fresh, 0, 0}.
+
+%% @doc The single, total value of a secure pn-counter.
+-spec value(state()) -> integer().
+value({_, Value, _}) when is_integer(Value) ->
+    Value.
+
+%% @doc Generate a downstream operation.
+%% The first parameter is either a tuple of the form `{increment, integer()}'
+%% or a tuple of the form `{increment, {integer(), integer()}}'. The first
+%% integer represents the delta value by which the counter will be incremented,
+%% while the second integer is the n squared value used by the Paillier
+%% cryptosystem. The second parameter is the secure pn-counter, this parameter
+%% is not actually used.
+-spec downstream(op(), state()) -> {ok, effect()}.
+downstream({increment, {Delta, NSquare}}, _SecurePNCounter)
+    when is_integer(Delta) and is_integer(Delta)
+->
+    {ok, {Delta, NSquare}};
+downstream({increment, Delta}, _SecurePNCounter) when is_integer(Delta) ->
+    {ok, Delta}.
+
+%% @doc Updates a given secure pn-counter, incrementing it by a given `Delta'.
+%% By incrementing we mean performing the homomorphic addition of the counter
+%% value with the given delta. As described by the Paillier cryptosystem, the
+%% homomorphic addition of plaintexts translates to the product of two
+%% ciphertexts modulo n squared.
+%%
+%% A value for `NSquare` may also be provided, if it isn't, the one in the
+%% counter state will be used.
+%%
+%% Returns the updated secure pn-counter.
+-spec update(effect(), state()) -> {ok, state()}.
+update({Delta, NSquare}, {fresh, _, _}) ->
+    {ok, {spoiled, Delta, NSquare}};
+update({Delta, NSquare}, {spoiled, Value, _}) ->
+    {ok, {spoiled, (Value * Delta) rem NSquare, NSquare}};
+update(Delta, {fresh, _, NSquare}) ->
+    {ok, {spoiled, Delta, NSquare}};
+update(Delta, {spoiled, Value, NSquare}) ->
+    {ok, {spoiled, (Value * Delta) rem NSquare, NSquare}}.
+
+%% @doc Compare if two secure counters are equal.
+-spec equal(state(), state()) -> boolean().
+equal(SecurePNCounter1, SecurePNCounter2) ->
+    SecurePNCounter1 =:= SecurePNCounter2.
+
+-spec to_binary(state()) -> binary().
+to_binary(SecurePNCounter) ->
+    term_to_binary(SecurePNCounter).
+
+-spec from_binary(binary()) -> {ok, state()}.
+from_binary(Bin) ->
+    {ok, binary_to_term(Bin)}.
+
+%% @doc The following function verifies that a given operation is supported by
+%% this particular CRDT.
+-spec is_operation(term()) -> boolean().
+is_operation({increment, {Delta, NSquare}}) when is_integer(Delta) and is_integer(NSquare) -> true;
+is_operation({increment, Delta}) when is_integer(Delta) -> true;
+is_operation(_) -> false.
+
+%% @doc Returns true if ?MODULE:downstream/2 needs the state of crdt
+%% to generate downstream effect.
+require_state_downstream(_) ->
+    false.
+
+%% ===================================================================
+%% EUnit tests
+%% ===================================================================
+-ifdef(TEST).
+
+%% @priv
+prepare_and_effect(Op, PNCounter) ->
+    {ok, Downstream} = downstream(Op, PNCounter),
+    update(Downstream, PNCounter).
+
+new_test() ->
+    ?assertEqual({fresh, 0, 0}, new()).
+
+value_test() ->
+    ?assertEqual(3, value({fresh, 3, 2})),
+    ?assertEqual(4, value({spoiled, 4, 2})).
+
+%% @doc Tests wether the secure pn-counter is correctly updated.
+update_test() ->
+    Counter = new(),
+    % Fresh counter without a given n squared.
+    {ok, Counter1} = prepare_and_effect({increment, 1}, Counter),
+    ?assertEqual({spoiled, 1, 0}, Counter1),
+    % Fresh counter with a given n squared.
+    {ok, Counter2} = prepare_and_effect({increment, {1, 1}}, Counter),
+    ?assertEqual({spoiled, 1, 1}, Counter2),
+    % Spoiled counter.
+    {ok, Counter3} = prepare_and_effect({increment, 2}, Counter2),
+    ?assertEqual({spoiled, 0, 1}, Counter3),
+    {ok, Counter4} = prepare_and_effect({increment, {2, 3}}, Counter2),
+    ?assertEqual({spoiled, 2, 3}, Counter4).
+
+equal_test() ->
+    Counter1 = {fresh, 4, 0},
+    Counter2 = {fresh, 2, 0},
+    Counter3 = {fresh, 2, 0},
+    ?assertNot(equal(Counter1, Counter2)),
+    ?assert(equal(Counter2, Counter3)).
+
+binary_test() ->
+    Counter1 = {spoiled, 4, 5},
+    BinaryCounter1 = to_binary(Counter1),
+    {ok, Counter2} = from_binary(BinaryCounter1),
+    ?assert(equal(Counter1, Counter2)).
+
+-endif.


### PR DESCRIPTION
This PR adds an implementation of a secure PN-Counter CRDT based on the Paillier cryptosystem, as well as an alias mechanism that allows one to map multiple CRDT types to one CRDT implementation. In this case, we map multiple secure CRDT types to their regular counterpart.